### PR TITLE
feat: harden download manager and libtorrent adapter

### DIFF
--- a/adapters/torrent/libtorrent.py
+++ b/adapters/torrent/libtorrent.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 import threading
 import time
@@ -37,6 +38,19 @@ import json
 class LibTorrent(BaseTorrentManager):
     name = "LibTorrent"
 
+    # Period (seconds) between bulk ``save_resume_data()`` requests.
+    # Keeps the on-disk ``.fastresume`` files in sync with the live
+    # torrent state so an interrupted download can pick up from the
+    # last checkpoint instead of force-rechecking every file from
+    # scratch on the next launch.
+    _RESUME_SAVE_INTERVAL_S: float = 30.0
+
+    # Filename pattern recognised by the resume loader. Matches the
+    # 40-char hex info-hashes that LibTorrent emits via
+    # ``str(handle.info_hash())`` plus the legacy 32-char base32 form,
+    # so manually-dropped files still get picked up.
+    _RESUME_FILENAME_RE = re.compile(r"^[0-9A-Fa-f]{32,40}\.fastresume$")
+
     def __init__(self, *args, **kwargs):
         if not LIBTORRENT_AVAILABLE:
             raise TorrentException(
@@ -46,6 +60,11 @@ class LibTorrent(BaseTorrentManager):
         self.handles = {}  # Maps hash to torrent_handle
         self._running = False
         self._thread = None
+        # On-disk location for ``.fastresume`` checkpoints. Set during
+        # :meth:`initialize` once we know the user's data root.
+        self._resume_data_dir: Optional[str] = None
+        # Drives the periodic resume-data save inside the alert loop.
+        self._last_resume_save: float = 0.0
         # Provide a sensible default download_path before calling BaseTorrentManager.__init__
         # BaseTorrentManager.__init__ may call login_dialog() when update=True, and
         # login_dialog expects `self.download_path` to exist.
@@ -106,6 +125,23 @@ class LibTorrent(BaseTorrentManager):
         if not self.download_path:
             return self.login_dialog()
 
+        # Co-locate the resume cache with the user's library so it is
+        # portable with their data path and survives across runs. We
+        # prefer the dataPath (the file manager's root) over the
+        # download_path so the directory is shared with the persisted
+        # ``.libtorrent`` cache used by other clients; if neither is
+        # set, fall back to the temp download path so the on-disk
+        # contract still holds for fresh installs.
+        resume_root = data_path or self.download_path
+        if resume_root:
+            try:
+                self._resume_data_dir = os.path.join(
+                    resume_root, ".libtorrent_resume"
+                )
+                os.makedirs(self._resume_data_dir, exist_ok=True)
+            except OSError:
+                self._resume_data_dir = None
+
         self.connect()
 
     def connect(self, thread=True):
@@ -138,6 +174,19 @@ class LibTorrent(BaseTorrentManager):
             self._thread = threading.Thread(target=self._session_thread, daemon=True)
             self._thread.start()
 
+            # Re-attach torrents from on-disk ``.fastresume`` files
+            # synchronously *in this connect thread* (which is itself
+            # backgrounded by :meth:`connect`). Loading before public
+            # API consumers see ``self._running=True``-gated calls
+            # like ``list()`` succeeding for the first time keeps the
+            # application-level DB restore in
+            # :class:`DownloadManager` from racing the loader and
+            # double-adding torrents that already exist on disk. The
+            # session alert loop runs concurrently to process the
+            # ``torrent_added_alert`` for each restored handle.
+            if self._resume_data_dir:
+                self._load_resume_data_dir()
+
         except Exception as e:
             print(f"Couldn't connect to LibTorrent: {str(e)}")  # TODO - use logger
             raise TorrentException(f"Failed to initialize LibTorrent session: {str(e)}")
@@ -156,13 +205,220 @@ class LibTorrent(BaseTorrentManager):
                         info_hash = str(alert.info_hash)
                         if info_hash in self.handles:
                             del self.handles[info_hash]
+                        self._delete_resume_file(info_hash)
                     elif isinstance(alert, lt.torrent_error_alert):
                         print(f"Torrent error: {alert.message}")  # TODO - use logger
+                    elif isinstance(
+                        alert, getattr(lt, "save_resume_data_alert", tuple())
+                    ):
+                        self._persist_resume_alert(alert)
+                    elif isinstance(
+                        alert,
+                        getattr(lt, "save_resume_data_failed_alert", tuple()),
+                    ):
+                        # Common when a checkpoint races with shutdown
+                        # or before metadata arrives; recoverable on
+                        # the next periodic save tick.
+                        pass
+                    elif isinstance(
+                        alert, getattr(lt, "metadata_received_alert", tuple())
+                    ):
+                        # First-time we know enough about the torrent
+                        # to capture a fastresume blob; trigger one
+                        # immediately so a freshly added magnet survives
+                        # an early shutdown.
+                        self._save_resume_data_for(alert.handle)
 
+                self._maybe_request_periodic_resume_save()
                 time.sleep(0.1)  # Small delay to prevent busy waiting
             except Exception as e:
                 print(f"Error in session thread: {str(e)}")  # TODO - use logger
                 break
+
+    def _maybe_request_periodic_resume_save(self) -> None:
+        """Fan out a ``save_resume_data`` request to every live handle.
+
+        Runs once per :attr:`_RESUME_SAVE_INTERVAL_S` seconds so the
+        on-disk checkpoints stay close to the live torrent state. The
+        actual write happens later, when the resulting
+        ``save_resume_data_alert`` flows through the alert loop.
+        """
+        if not self._resume_data_dir or not self.session:
+            return
+        now = time.time()
+        if now - self._last_resume_save < self._RESUME_SAVE_INTERVAL_S:
+            return
+        self._last_resume_save = now
+        for handle in list(self.handles.values()):
+            self._save_resume_data_for(handle)
+
+    @staticmethod
+    def _save_resume_data_for(handle: Any) -> None:
+        """Request resume data for ``handle`` if it is ready.
+
+        ``save_resume_data()`` on a handle without metadata raises in
+        older libtorrent builds; check ``has_metadata`` (and
+        ``is_valid``) so the alert loop doesn't take collateral damage
+        from a single just-added magnet.
+        """
+        try:
+            if not handle.is_valid():
+                return
+            if not handle.has_metadata():
+                return
+            handle.save_resume_data()
+        except Exception:
+            return
+
+    def _resume_data_blob(self, alert: Any) -> Optional[bytes]:
+        """Serialize an alert into a bencoded fastresume payload.
+
+        Newer libtorrent (>=1.2) exposes ``alert.params`` plus
+        ``lt.write_resume_data_buf``; older versions hand back
+        ``alert.resume_data`` (an ``entry`` dict) that has to be
+        ``lt.bencode``'d. We try both transparently so the same code
+        works against whichever build the user has installed.
+        """
+        if lt is None:
+            return None
+        write_buf = getattr(lt, "write_resume_data_buf", None)
+        params = getattr(alert, "params", None)
+        if callable(write_buf) and params is not None:
+            try:
+                buf = write_buf(params)
+            except Exception:
+                buf = None
+            if buf is not None:
+                return bytes(buf)
+        # Legacy fallback: entry + bencode.
+        entry = getattr(alert, "resume_data", None)
+        bencode = getattr(lt, "bencode", None)
+        if entry is not None and callable(bencode):
+            try:
+                return bytes(bencode(entry))
+            except Exception:
+                return None
+        return None
+
+    def _persist_resume_alert(self, alert: Any) -> None:
+        """Write the alert payload to ``<hash>.fastresume`` atomically."""
+        if not self._resume_data_dir:
+            return
+        try:
+            info_hash = str(alert.handle.info_hash())
+        except Exception:
+            return
+        if not info_hash:
+            return
+        blob = self._resume_data_blob(alert)
+        if blob is None:
+            return
+        path = os.path.join(self._resume_data_dir, f"{info_hash}.fastresume")
+        tmp = path + ".tmp"
+        try:
+            with open(tmp, "wb") as f:
+                f.write(blob)
+            os.replace(tmp, path)
+        except OSError:
+            # Don't let an I/O hiccup crash the alert loop; the next
+            # periodic checkpoint will retry.
+            try:
+                if os.path.exists(tmp):
+                    os.unlink(tmp)
+            except OSError:
+                pass
+
+    def _delete_resume_file(self, info_hash: str) -> None:
+        """Remove the fastresume entry for a torrent that was removed."""
+        if not self._resume_data_dir or not info_hash:
+            return
+        candidate = os.path.join(
+            self._resume_data_dir, f"{info_hash}.fastresume"
+        )
+        try:
+            if os.path.isfile(candidate):
+                os.unlink(candidate)
+        except OSError:
+            pass
+
+    def _load_resume_data_dir(self) -> None:
+        """Re-add every torrent we have a fastresume checkpoint for.
+
+        Runs once at startup. Each file is decoded via
+        :func:`lt.read_resume_data` (or ``add_torrent_params``'s
+        ``resume_data`` slot on older builds) so the session takes the
+        partial pieces / paused state into account; libtorrent then
+        skips the full force-recheck that a magnet-only restore would
+        trigger, which is what makes long-running downloads feel
+        "remembered" across restarts.
+        """
+        if lt is None or not self._resume_data_dir:
+            return
+        if not os.path.isdir(self._resume_data_dir):
+            return
+        if self.session is None:
+            return
+
+        try:
+            names = os.listdir(self._resume_data_dir)
+        except OSError:
+            return
+        for name in names:
+            if not self._RESUME_FILENAME_RE.match(name):
+                continue
+            path = os.path.join(self._resume_data_dir, name)
+            try:
+                with open(path, "rb") as f:
+                    blob = f.read()
+            except OSError:
+                continue
+            if not blob:
+                continue
+            try:
+                self._add_from_resume_blob(blob)
+            except Exception as e:
+                # Mirror the logging shape used elsewhere in this file.
+                print(  # TODO - use logger
+                    f"Failed to restore torrent from {name}: {str(e)}"
+                )
+
+    def _add_from_resume_blob(self, blob: bytes) -> None:
+        """Add a torrent to the session using a fastresume payload."""
+        if self.session is None:
+            return
+        params = None
+        # Preferred (>=1.2): build ``add_torrent_params`` from the blob.
+        reader = getattr(lt, "read_resume_data", None)
+        if callable(reader):
+            try:
+                params = reader(blob)
+            except Exception:
+                params = None
+        if params is not None:
+            # Make sure the save path stays where the existing files
+            # already live; an empty save_path on the reconstituted
+            # params would point the torrent at the wrong directory.
+            if not getattr(params, "save_path", None):
+                try:
+                    params.save_path = self.download_path
+                except Exception:
+                    pass
+            handle = self.session.add_torrent(params)
+        else:
+            # Legacy fallback: ``add_torrent`` accepts a dict with a
+            # ``resume_data`` slot. We don't know the original save
+            # path here, so default to the configured download_path.
+            add_params = {
+                "save_path": self.download_path,
+                "resume_data": blob,
+            }
+            handle = self.session.add_torrent(add_params)
+        try:
+            info_hash = str(handle.info_hash())
+        except Exception:
+            return
+        if info_hash:
+            self.handles[info_hash] = handle
 
     def login_dialog(self, failed=False):
         fields = {
@@ -305,6 +561,12 @@ class LibTorrent(BaseTorrentManager):
                         "save_path": save_path,
                     }
                 )
+
+                # For .torrent files we already have metadata, so a
+                # baseline fastresume checkpoint can be captured right
+                # now. Magnets without metadata get their first
+                # checkpoint via the ``metadata_received_alert`` path.
+                self._save_resume_data_for(handle)
             except TorrentException:
                 raise
             except Exception as e:
@@ -470,27 +732,88 @@ class LibTorrent(BaseTorrentManager):
         return state_map.get(status.state, "unknown")
 
     def close(self):
-        """Clean shutdown of the LibTorrent session"""
+        """Clean shutdown of the LibTorrent session.
+
+        Captures the final resume-data snapshot synchronously before
+        tearing the alert thread down. Without that synchronous step
+        the resume-data alerts emitted by ``handle.save_resume_data()``
+        would still be in the alert queue when we set ``_running=False``
+        and never reach :meth:`_persist_resume_alert`, leaving the
+        last few seconds of progress unpersisted -- which is the exact
+        "the app forgot my torrents" symptom users hit on a clean
+        close right after starting / completing a download.
+        """
+        session = self.session
+        if session is not None:
+            try:
+                session.pause()
+            except Exception:
+                pass
+            self._drain_resume_data_on_close(session)
+
+        # Now it is safe to stop the alert loop and tear the session
+        # down; any outstanding alerts have already been handled above.
         self._running = False
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5)
 
-        if self.session:
+        if session is not None:
             try:
-                self.session.pause()
-                # Save resume data for all torrents
-                for handle in self.handles.values():
-                    if handle.is_valid():
-                        handle.save_resume_data()
-
-                # Wait a bit for resume data to be saved
-                time.sleep(1)
-
+                # Older libtorrent builds expose ``pause()`` but no
+                # explicit shutdown method; dropping our reference is
+                # enough for the session destructor to clean up.
+                self.session = None
             except Exception as e:
                 print(f"Error during session cleanup: {str(e)}")  # TODO - use logger
-            finally:
-                self.session = None
-                self.handles.clear()
+        self.handles.clear()
+
+    def _drain_resume_data_on_close(self, session: Any) -> None:
+        """Request and persist resume data for every live handle.
+
+        Walks the session synchronously: enqueue ``save_resume_data``
+        for each handle that has metadata, then keep popping alerts
+        from the session in this thread (without interleaving the
+        background alert loop, which we're about to stop) until every
+        outstanding request has either resolved or the grace period
+        expires. Avoids the historical race where the destructor fired
+        before the resume-data alerts were drained.
+        """
+        if not self._resume_data_dir:
+            return
+        pending = 0
+        for handle in list(self.handles.values()):
+            try:
+                if not handle.is_valid():
+                    continue
+                if not handle.has_metadata():
+                    continue
+                handle.save_resume_data()
+                pending += 1
+            except Exception:
+                continue
+        if pending == 0:
+            return
+
+        deadline = time.time() + 5.0
+        while pending > 0 and time.time() < deadline:
+            try:
+                alerts = session.pop_alerts()
+            except Exception:
+                break
+            if not alerts:
+                time.sleep(0.1)
+                continue
+            for alert in alerts:
+                if isinstance(
+                    alert, getattr(lt, "save_resume_data_alert", tuple())
+                ):
+                    self._persist_resume_alert(alert)
+                    pending -= 1
+                elif isinstance(
+                    alert,
+                    getattr(lt, "save_resume_data_failed_alert", tuple()),
+                ):
+                    pending -= 1
 
     def __del__(self):
         """Destructor to ensure clean shutdown"""

--- a/application/services/download_manager.py
+++ b/application/services/download_manager.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from shared.base_component import BaseComponent
 from shared.security import validate_url
-from adapters.legacy.legacy_classes import Magnet, Torrent
+from application.bridges.legacy_entities import Magnet, Torrent
 
 
 class DownloadManager(BaseComponent):
@@ -62,6 +62,9 @@ class DownloadManager(BaseComponent):
             name="DownloadProcessor",
         )
         self._processor.start()
+        self._restore_persisted_thread_started = False
+        self._restore_session_lock = threading.Lock()
+        self._persisted_restore_completed = False
 
     def close(self) -> None:
         """Cancel in-flight downloads and release worker resources."""
@@ -94,6 +97,147 @@ class DownloadManager(BaseComponent):
     def set_database_manager(self, database_manager) -> None:
         """Attach the database manager used to persist torrent metadata."""
         self._database_manager = database_manager
+
+    def schedule_restore_persisted_torrents_after_startup(self) -> None:
+        """Best-effort early restore on a background thread.
+
+        The authoritative pass also runs from :meth:`get_torrents_overview`
+        the first time the UI (or any client) asks for torrent state, so we
+        never miss the window where LibTorrent's session finishes connecting
+        after process start.
+        """
+        if self._restore_persisted_thread_started:
+            return
+        self._restore_persisted_thread_started = True
+        threading.Thread(
+            target=self._restore_persisted_torrents_worker,
+            daemon=True,
+            name="LibTorrentPersistedRestore",
+        ).start()
+
+    def _restore_persisted_torrents_worker(self) -> None:
+        try:
+            self._maybe_restore_persisted_torrents()
+        except Exception as exc:  # noqa: BLE001
+            self.log(
+                "DOWNLOAD_MANAGER",
+                f"Persisted torrent restore worker failed: {exc}",
+            )
+
+    @staticmethod
+    def _torrent_manager_uses_ephemeral_session(tm: Any) -> bool:
+        """True for embedded LibTorrent (empty session every process start)."""
+        return tm is not None and getattr(tm, "name", None) == "LibTorrent"
+
+    def _maybe_restore_persisted_torrents(self) -> None:
+        """Re-add persisted LibTorrent jobs once the client session is ready.
+
+        Runs from the background worker and from :meth:`get_torrents_overview`
+        so a cold start never depends on thread ordering alone. If LibTorrent
+        is still connecting, we leave ``_persisted_restore_completed`` false
+        and try again on the next overview poll.
+        """
+        if self._persisted_restore_completed:
+            return
+        tm = self._torrent_manager
+        if tm is None:
+            return
+        if not self._torrent_manager_uses_ephemeral_session(tm):
+            with self._restore_session_lock:
+                self._persisted_restore_completed = True
+            return
+        with self._restore_session_lock:
+            if self._persisted_restore_completed:
+                return
+            outcome = self._restore_persisted_torrents_once()
+            if outcome is None:
+                return
+            self._persisted_restore_completed = True
+
+    def _restore_persisted_torrents_once(self) -> Optional[int]:
+        """Wait for LibTorrent, then re-queue any DB torrents missing from the client.
+
+        Returns:
+            ``None`` if the torrent client never became ready in time (or a
+            subsequent ``list()`` failed) so the caller can retry later.
+            Otherwise the number of torrents successfully submitted (may be ``0``).
+        """
+        tm = self._torrent_manager
+        if tm is None or not self._torrent_manager_uses_ephemeral_session(tm):
+            return 0
+        db_manager = self._database_manager
+        if db_manager is None:
+            return 0
+
+        deadline = time.time() + 45.0
+        while time.time() < deadline:
+            try:
+                tm.list()
+            except Exception:
+                time.sleep(0.4)
+                continue
+            break
+        else:
+            self.log(
+                "DOWNLOAD_MANAGER",
+                "Persisted torrent restore skipped: torrent client not ready in time",
+            )
+            return None
+
+        try:
+            pairs = db_manager.list_anime_torrent_pairs()
+        except Exception as exc:
+            self.log(
+                "DOWNLOAD_MANAGER",
+                f"Persisted torrent restore: could not read index: {exc}",
+            )
+            return 0
+        if not pairs:
+            return 0
+
+        try:
+            live = tm.list() or []
+        except Exception as exc:
+            self.log(
+                "DOWNLOAD_MANAGER",
+                f"Persisted torrent restore: list() failed: {exc}",
+            )
+            return None
+
+        current: set[str] = set()
+        for entry in live:
+            h = self._extract_torrent_field(entry, "hash")
+            if h:
+                current.add(str(h).strip().lower())
+
+        restored = 0
+        for anime_id, hash_value in pairs:
+            hl = str(hash_value).strip().lower()
+            if not hl or hl in current:
+                continue
+            task = DownloadTask(anime_id, hash_value=hash_value)
+            torrent = self._prepare_torrent(task)
+            if not torrent or not hasattr(torrent, "to_magnet"):
+                continue
+            try:
+                folder = self._resolve_anime_media_folder_for_restore(anime_id)
+                if not folder:
+                    continue
+                if self._start_download(anime_id, torrent, folder_path=folder):
+                    restored += 1
+                    current.add(hl)
+            except Exception as exc:
+                self.log(
+                    "DOWNLOAD_MANAGER",
+                    f"Restore torrent hash={hl!r} anime_id={anime_id}: {exc}",
+                )
+
+        if restored:
+            self.log(
+                "DOWNLOAD_MANAGER",
+                f"Restored {restored} persisted torrent(s) for seeding after startup",
+            )
+        return restored
 
     def set_watching_tag_callback(
         self, callback: Optional[Callable[[int, int], None]]
@@ -136,7 +280,32 @@ class DownloadManager(BaseComponent):
             Number of torrents queued for redownload
         """
         self.log("DOWNLOAD_MANAGER", f"Redownload requested for anime {anime_id}")
-        return 0
+        db_manager = self._database_manager
+        if db_manager is None:
+            return 0
+        try:
+            pairs = list(db_manager.list_anime_torrent_pairs() or [])
+        except Exception as exc:
+            self.log("DOWNLOAD_MANAGER", f"Redownload lookup failed: {exc}")
+            return 0
+        queued = 0
+        seen_hashes: set[str] = set()
+        for aid, hash_value in pairs:
+            try:
+                if int(aid) != int(anime_id):
+                    continue
+            except (TypeError, ValueError):
+                continue
+            hash_clean = str(hash_value or "").strip()
+            if not hash_clean:
+                continue
+            hash_key = hash_clean.lower()
+            if hash_key in seen_hashes:
+                continue
+            seen_hashes.add(hash_key)
+            if self.download_file(anime_id, hash_value=hash_clean) is not None:
+                queued += 1
+        return queued
 
     def cancel_download(self, anime_id: int) -> bool:
         """
@@ -281,6 +450,7 @@ class DownloadManager(BaseComponent):
         Torrents that have no matching anime row are still returned so
         the user can see them and decide whether to clean them up.
         """
+        self._maybe_restore_persisted_torrents()
         empty: Dict[str, List[Dict[str, Any]]] = {
             "active": [],
             "seeding": [],
@@ -708,7 +878,20 @@ class DownloadManager(BaseComponent):
                 if db_manager is not None:
                     data = db_manager.get_torrent_data(task.hash_value)
                     if data:
-                        return Torrent(hash=task.hash_value, name=data[0], trackers=data[1])
+                        # ``data[1]`` is whatever shape the persistence
+                        # layer chose; we always store JSON since the
+                        # ``DatabaseManager.save_torrent`` rewrite, but
+                        # older rows may still be plain text. Decode
+                        # back to a list so :meth:`Torrent.to_magnet`
+                        # emits a proper ``&tr=<url>`` per tracker
+                        # instead of urlencoding the JSON string itself
+                        # one character at a time.
+                        trackers = self._decode_persisted_trackers(data[1])
+                        return Torrent(
+                            hash=task.hash_value,
+                            name=data[0],
+                            trackers=trackers,
+                        )
 
         except Exception as e:
             self.log("DOWNLOAD_MANAGER", f"Error preparing torrent: {e}")
@@ -725,6 +908,37 @@ class DownloadManager(BaseComponent):
         except Exception as exc:
             self.log("DOWNLOAD_MANAGER", f"Error saving torrent: {exc}")
 
+    @staticmethod
+    def _decode_persisted_trackers(value: Any) -> list[str]:
+        """Coerce the stored ``trackers`` column back into a list of URLs.
+
+        ``DatabaseManager.save_torrent`` writes a JSON array, but the
+        adapter contract is intentionally permissive (older rows may
+        carry plain text, list-likes, or ``None``). Returning a list
+        unconditionally keeps :meth:`Torrent.to_magnet` from iterating
+        a stray string char by char.
+        """
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple, set)):
+            return [str(v) for v in value if v]
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            if stripped.startswith("["):
+                try:
+                    import json as _json
+
+                    decoded = _json.loads(stripped)
+                except Exception:
+                    return [stripped]
+                if isinstance(decoded, list):
+                    return [str(v) for v in decoded if v]
+                return [str(decoded)] if decoded else []
+            return [stripped]
+        return [str(value)]
+
     def _set_user_tag(self, anime_id: int, user_id: int) -> None:
         """Promote library tag to ``WATCHING`` when a download is tied to a user."""
         self.log("DOWNLOAD_MANAGER", f"Watching-tag hook for anime {anime_id}, user {user_id}")
@@ -738,13 +952,20 @@ class DownloadManager(BaseComponent):
                 "DOWNLOAD_MANAGER",
                 f"Watching-tag callback failed for anime {anime_id}: {exc}",
             )
-    def _start_download(self, anime_id: int, torrent: Torrent) -> bool:
+    def _start_download(
+        self,
+        anime_id: int,
+        torrent: Torrent,
+        *,
+        folder_path: Optional[str] = None,
+    ) -> bool:
         """
         Start the actual download.
 
         Args:
             anime_id: Anime ID
             torrent: Torrent object
+            folder_path: Optional save path; defaults to :meth:`_get_anime_folder`.
 
         Returns:
             True if download started successfully
@@ -753,14 +974,16 @@ class DownloadManager(BaseComponent):
             if not self._torrent_manager or not hasattr(torrent, "to_magnet"):
                 return False
 
-            folder_path = self._get_anime_folder(anime_id)
-            if not folder_path:
+            resolved = folder_path or self._get_anime_folder(anime_id)
+            if not resolved:
                 return False
 
-            torrents = self._torrent_manager.add([torrent.to_magnet()], path=folder_path)
+            torrents = self._torrent_manager.add(
+                [torrent.to_magnet()], path=resolved
+            )
 
             if torrents:
-                self._move_torrents_to_folder(torrents, folder_path)
+                self._move_torrents_to_folder(torrents, resolved)
 
             return bool(torrents)
 
@@ -874,6 +1097,64 @@ class DownloadManager(BaseComponent):
         if title in (None, ""):
             return None
         return str(title)
+
+    @staticmethod
+    def _folder_direct_file_weight(path: str) -> int:
+        """Total size in bytes of regular files directly under ``path``."""
+        total = 0
+        try:
+            with os.scandir(path) as entries:
+                for ent in entries:
+                    if ent.is_file(follow_symlinks=False):
+                        try:
+                            total += ent.stat().st_size
+                        except OSError:
+                            pass
+        except OSError:
+            pass
+        return total
+
+    def _resolve_anime_media_folder_for_restore(self, anime_id: int) -> Optional[str]:
+        """Pick the on-disk folder that already holds this anime's media.
+
+        After a metadata refresh the sanitized title (and thus folder name)
+        can change while completed torrents still live under the old
+        ``… - <id>`` directory. We prefer any existing ``Animes`` subfolder
+        whose name ends with `` - <id>`` (or equals ``anime_<id>``) and has
+        files, then fall back to :meth:`_get_anime_folder`.
+        """
+        fm = self._file_manager
+        data_path = ""
+        if fm is not None:
+            settings = getattr(fm, "settings", None)
+            if isinstance(settings, dict):
+                data_path = str(settings.get("dataPath") or "").strip()
+
+        if not data_path:
+            return self._get_anime_folder(anime_id)
+
+        animes_root = os.path.join(data_path, "Animes")
+        suffix = f" - {anime_id}"
+        legacy = f"anime_{anime_id}"
+        candidates: list[str] = []
+        try:
+            if os.path.isdir(animes_root):
+                for name in os.listdir(animes_root):
+                    if not (name.endswith(suffix) or name == legacy):
+                        continue
+                    full = os.path.join(animes_root, name)
+                    if os.path.isdir(full):
+                        candidates.append(full)
+        except OSError:
+            candidates = []
+
+        if candidates:
+            candidates.sort(
+                key=lambda p: self._folder_direct_file_weight(p), reverse=True
+            )
+            return candidates[0]
+
+        return self._get_anime_folder(anime_id)
 
     def _move_torrents_to_folder(self, torrents, folder_path: str) -> None:
         """

--- a/clients/tk/views/torrent_download.py
+++ b/clients/tk/views/torrent_download.py
@@ -6,6 +6,8 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Any
 
+from domain.entities import title_variants_for_torrent_search
+
 from clients.tk.presenters import AnimeBrowserPresenter
 from clients.tk.theme import apply_dark_theme
 
@@ -25,7 +27,10 @@ class TorrentDownloadDialog(tk.Toplevel):
         self._anime = anime
         self._rows: list[dict[str, Any]] = []
 
-        self._term = tk.StringVar(value=anime.get("title") or "")
+        variants = title_variants_for_torrent_search(anime)
+        self._term = tk.StringVar(
+            value=", ".join(variants) if variants else (anime.get("title") or "")
+        )
         self._profile = tk.StringVar(value="interactive")
         self._status = tk.StringVar(value="Ready")
         self._build()

--- a/tests/unit/components/test_download_manager_edges.py
+++ b/tests/unit/components/test_download_manager_edges.py
@@ -6,6 +6,8 @@ network, never start real torrent clients, and never touch disk.
 
 from __future__ import annotations
 
+import json
+import os
 import queue
 import threading
 import time
@@ -242,6 +244,10 @@ class _FakeDB:
         self.saved = []
         self.torrent_data: Dict[str, Any] = {}
         self.raise_save = False
+        self.pairs: List[tuple[int, str]] = []
+
+    def list_anime_torrent_pairs(self):
+        return list(self.pairs)
 
     def save_torrent(self, anime_id, torrent):
         if self.raise_save:
@@ -583,6 +589,55 @@ class TestPrepareTorrentDetails:
             result = mgr._prepare_torrent(task)
             assert result is not None
             assert getattr(result, "hash") == "dead"
+            # Trackers must survive as a list so ``to_magnet`` emits a
+            # proper ``&tr=<url>`` per entry rather than treating a
+            # JSON string as an iterable of characters.
+            assert list(getattr(result, "trackers") or []) == ["udp://t1"]
+        finally:
+            mgr.close()
+
+    def test_prepare_torrent_via_hash_decodes_json_trackers(
+        self, DownloadManager, DownloadTask
+    ):
+        """Persisted ``trackers`` rows are JSON strings -- decoding
+        them on restore is what keeps a re-added magnet pointing at
+        the original tracker tier instead of urlencoding the literal
+        JSON one character at a time."""
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        db = MagicMock()
+        db.get_torrent_data.return_value = (
+            "Naruto",
+            '["udp://t1", "udp://t2"]',
+        )
+        mgr.set_database_manager(db)
+        try:
+            task = DownloadTask(1, hash_value="dead")
+            result = mgr._prepare_torrent(task)
+            assert result is not None
+            assert list(getattr(result, "trackers") or []) == [
+                "udp://t1",
+                "udp://t2",
+            ]
+        finally:
+            mgr.close()
+
+    def test_decode_persisted_trackers_handles_shapes(self, DownloadManager):
+        """The helper must coerce every plausible persisted shape into
+        a list of URLs without raising."""
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        try:
+            f = mgr._decode_persisted_trackers
+            assert f(None) == []
+            assert f([]) == []
+            assert f("") == []
+            assert f("   ") == []
+            assert f("udp://only") == ["udp://only"]
+            assert f("not json [oops") == ["not json [oops"]
+            assert f('["a","b"]') == ["a", "b"]
+            assert f(["a", "b"]) == ["a", "b"]
+            assert f(("a", "b")) == ["a", "b"]
         finally:
             mgr.close()
 
@@ -718,6 +773,20 @@ class TestLifecycle:
         mgr.log = _silent_logger
         try:
             assert mgr.redownload(123) == 0
+        finally:
+            mgr.close()
+
+    def test_redownload_requeues_persisted_hashes(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        db = _FakeDB()
+        db.pairs = [(10, "a" * 40), (10, "a" * 40), (11, "b" * 40)]
+        mgr.set_database_manager(db)
+        try:
+            with patch.object(mgr, "download_file", return_value=queue.Queue()) as dl:
+                queued = mgr.redownload(10)
+            assert queued == 1
+            dl.assert_called_once_with(10, hash_value="a" * 40)
         finally:
             mgr.close()
 
@@ -1059,5 +1128,106 @@ class TestTorrentsOverview:
             assert len(actives) == 1
             assert actives[0]["anime_id"] == 1
             assert actives[0]["name"] == "queued.mkv"
+        finally:
+            mgr.close()
+
+
+# ---------------------------------------------------------------------------
+# Persisted torrent restore (LibTorrent cold start)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistedTorrentRestore:
+    def test_restore_once_skips_non_libtorrent(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        tm = MagicMock()
+        tm.name = "qBittorrent"
+        tm.list.return_value = []
+        mgr.set_torrent_manager(tm)
+        db = _FakeDB()
+        db.pairs = [(1, "a" * 40)]
+        mgr.set_database_manager(db)
+        try:
+            assert mgr._restore_persisted_torrents_once() == 0
+            tm.add.assert_not_called()
+        finally:
+            mgr.close()
+
+    def test_restore_once_readds_persisted_not_in_session(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        tm = MagicMock()
+        tm.name = "LibTorrent"
+        tm.list.return_value = []
+        mgr.set_torrent_manager(tm)
+        h = "a" * 40
+        db = _FakeDB()
+        db.pairs = [(9, h)]
+        db.torrent_data[h] = (
+            "Episode",
+            json.dumps(["udp://tracker.example:80/announce"]),
+        )
+        mgr.set_database_manager(db)
+        tm.add.return_value = [{"hash": h, "name": "Episode"}]
+        try:
+            with patch.object(mgr, "_get_anime_folder", return_value="/tmp/a9"):
+                n = mgr._restore_persisted_torrents_once()
+            assert n == 1
+            tm.add.assert_called_once()
+            magnet = tm.add.call_args[0][0][0]
+            assert h in magnet
+            assert "magnet:?" in magnet
+        finally:
+            mgr.close()
+
+    def test_restore_once_skips_pairs_already_live(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        h = "b" * 40
+        tm = MagicMock()
+        tm.name = "LibTorrent"
+        tm.list.return_value = [{"hash": h, "name": "x", "state": "seeding"}]
+        mgr.set_torrent_manager(tm)
+        db = _FakeDB()
+        db.pairs = [(1, h)]
+        db.torrent_data[h] = ("N", "[]")
+        mgr.set_database_manager(db)
+        try:
+            assert mgr._restore_persisted_torrents_once() == 0
+            tm.add.assert_not_called()
+        finally:
+            mgr.close()
+
+    def test_schedule_restore_is_idempotent(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        try:
+            mgr.schedule_restore_persisted_torrents_after_startup()
+            mgr.schedule_restore_persisted_torrents_after_startup()
+            assert mgr._restore_persisted_thread_started is True
+        finally:
+            mgr.close()
+
+    def test_resolve_restore_folder_prefers_heavier_suffix_match(
+        self, DownloadManager, tmp_path
+    ):
+        """When two ``* - <id>`` folders exist, pick the one with more file bytes."""
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        data = tmp_path / "data"
+        animes = data / "Animes"
+        light = animes / "Old Title - 42"
+        heavy = animes / "New Title - 42"
+        light.mkdir(parents=True)
+        heavy.mkdir(parents=True)
+        (light / "a.txt").write_text("x", encoding="utf-8")
+        (heavy / "b.bin").write_bytes(b"x" * 5000)
+        fm = MagicMock()
+        fm.settings = {"dataPath": str(data)}
+        mgr.set_file_manager(fm)
+        try:
+            picked = mgr._resolve_anime_media_folder_for_restore(42)
+            assert os.path.normcase(picked) == os.path.normcase(str(heavy))
         finally:
             mgr.close()

--- a/tests/unit/components/test_download_manager_restore_more.py
+++ b/tests/unit/components/test_download_manager_restore_more.py
@@ -1,0 +1,94 @@
+"""Additional restore and overview tests for :class:`DownloadManager`."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def DownloadManager():
+    from application.services.download_manager import DownloadManager as _DM
+
+    return _DM
+
+
+def _silent_logger(*_a, **_kw):
+    return None
+
+
+class _FakeDB:
+    def __init__(self, pairs=None, torrent_data=None):
+        self.pairs = list(pairs or [])
+        self.torrent_data = dict(torrent_data or {})
+
+    def list_anime_torrent_pairs(self):
+        return list(self.pairs)
+
+    def get_torrent_data(self, hash_value):
+        return self.torrent_data.get(str(hash_value).lower())
+
+
+class TestRestoreMore:
+    def test_restore_waits_then_returns_none_when_list_never_ready(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        tm = MagicMock()
+        tm.name = "LibTorrent"
+        tm.list.side_effect = RuntimeError("not ready")
+        mgr.set_torrent_manager(tm)
+        mgr.set_database_manager(_FakeDB(pairs=[(1, "a" * 40)]))
+        try:
+            with patch.object(time, "time", side_effect=[0.0, 100.0]):
+                assert mgr._restore_persisted_torrents_once() is None
+        finally:
+            mgr.close()
+
+    def test_restore_list_failure_after_ready_returns_none(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        tm = MagicMock()
+        tm.name = "LibTorrent"
+        tm.list.side_effect = [None, RuntimeError("list failed")]
+        mgr.set_torrent_manager(tm)
+        mgr.set_database_manager(_FakeDB(pairs=[(1, "c" * 40)]))
+        try:
+            assert mgr._restore_persisted_torrents_once() is None
+        finally:
+            mgr.close()
+
+    def test_maybe_restore_marks_complete_for_non_libtorrent(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        tm = MagicMock()
+        tm.name = "Transmission"
+        mgr.set_torrent_manager(tm)
+        try:
+            mgr._maybe_restore_persisted_torrents()
+            assert mgr._persisted_restore_completed is True
+        finally:
+            mgr.close()
+
+    def test_close_shuts_down_executor(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        executor = mgr._executor
+        mgr.close()
+        assert mgr._executor is None
+        assert executor is not None
+
+
+class TestWatchingTagCallback:
+    def test_watching_callback_invoked(self, DownloadManager):
+        mgr = DownloadManager(max_concurrent_downloads=1)
+        mgr.log = _silent_logger
+        calls: list[tuple[int, int]] = []
+        mgr.set_watching_tag_callback(lambda aid, uid: calls.append((aid, uid)))
+        try:
+            mgr._set_user_tag(1, 9)
+        finally:
+            mgr.close()
+        assert calls == [(1, 9)]

--- a/tests/unit/core/test_persistence_queue_edges.py
+++ b/tests/unit/core/test_persistence_queue_edges.py
@@ -62,6 +62,14 @@ class TestStartStopIdempotence:
         flat = sorted(item for batch in received for item in batch)
         assert flat == [0, 1, 2, 3, 4]
 
+    def test_stop_without_drain_skips_join(self):
+        received = []
+        pq = _build(received, batch_size=1000, max_latency_ms=10_000)
+        pq.start()
+        pq.put(1, block=True)
+        pq.stop(drain=False, timeout=0.01)
+        pq.stop()  # idempotent after worker handle cleared
+
 
 class TestFlushNow:
     def test_flush_now_on_empty_does_nothing(self):

--- a/tests/unit/torrent_managers/test_libtorrent_fastresume.py
+++ b/tests/unit/torrent_managers/test_libtorrent_fastresume.py
@@ -1,0 +1,226 @@
+"""Fastresume persistence tests for the LibTorrent adapter.
+
+These tests exercise the on-disk ``.fastresume`` checkpoint pipeline
+without spinning a real libtorrent session: the alert types and the
+write/read helpers are stubbed on the adapter's module-level ``lt``
+reference so the logic stays deterministic on CI machines that ship
+without ``python-libtorrent`` installed.
+
+The behaviour under test is the one the user-facing complaint is
+about: starting the app after a clean shutdown must not lose the
+torrents that were active or completed/seeding in the previous
+session. The application restores from two complementary sources:
+
+* :class:`DownloadManager` walks the persisted ``torrentsIndex`` and
+  re-adds via magnet (tested in ``test_download_manager_edges``).
+* :class:`LibTorrent` walks ``<dataPath>/.libtorrent_resume/*.fastresume``
+  and re-adds with partial-state metadata, which is what allows a
+  half-finished download to keep its progress instead of force-
+  rechecking from scratch.
+
+Both paths are idempotent: if a torrent has already been re-added by
+one path, the other one's ``add_torrent`` call returns the existing
+handle.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytest.importorskip(
+    "adapters.torrent.libtorrent",
+    reason="LibTorrent adapter module is not importable",
+)
+
+
+def _make_libtorrent_adapter(tmp_path, monkeypatch):
+    """Construct a LibTorrent instance with a stubbed ``lt`` module.
+
+    Bypasses :meth:`BaseTorrentManager.__init__` so the test doesn't
+    pay the cost of spinning a real libtorrent session; we exercise the
+    fastresume helpers directly against an isolated tempdir.
+    """
+    from adapters.torrent import libtorrent as lt_module
+
+    # Mark libtorrent as available so the constructor doesn't bail.
+    monkeypatch.setattr(lt_module, "LIBTORRENT_AVAILABLE", True)
+    # Stub out the libtorrent alert classes the adapter introspects.
+    fake_lt = SimpleNamespace(
+        save_resume_data_alert=type("save_resume_data_alert", (), {}),
+        save_resume_data_failed_alert=type(
+            "save_resume_data_failed_alert", (), {}
+        ),
+        metadata_received_alert=type("metadata_received_alert", (), {}),
+        torrent_added_alert=type("torrent_added_alert", (), {}),
+        torrent_removed_alert=type("torrent_removed_alert", (), {}),
+        torrent_error_alert=type("torrent_error_alert", (), {}),
+        bencode=lambda v: b"BENC|" + str(v).encode("utf-8"),
+        write_resume_data_buf=lambda params: bytes(params),
+        read_resume_data=lambda blob: SimpleNamespace(
+            save_path="", resume_data=blob
+        ),
+    )
+    monkeypatch.setattr(lt_module, "lt", fake_lt)
+
+    adapter = lt_module.LibTorrent.__new__(lt_module.LibTorrent)
+    adapter.session = MagicMock()
+    adapter.handles = {}
+    adapter._running = False
+    adapter._thread = None
+    adapter.download_path = str(tmp_path / "downloads")
+    os.makedirs(adapter.download_path, exist_ok=True)
+    adapter._resume_data_dir = str(tmp_path / ".libtorrent_resume")
+    os.makedirs(adapter._resume_data_dir, exist_ok=True)
+    adapter._last_resume_save = 0.0
+    return adapter, fake_lt, lt_module
+
+
+class TestFastResumeChecking:
+    def test_persist_resume_alert_writes_atomic_file(
+        self, tmp_path, monkeypatch
+    ):
+        adapter, fake_lt, _ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        handle = SimpleNamespace(info_hash=lambda: "a" * 40)
+        params = b"resume-data-blob"
+        alert = SimpleNamespace(handle=handle, params=params, resume_data=None)
+        adapter._persist_resume_alert(alert)
+
+        out = os.path.join(adapter._resume_data_dir, ("a" * 40) + ".fastresume")
+        assert os.path.isfile(out)
+        with open(out, "rb") as f:
+            assert f.read() == params
+
+    def test_persist_resume_alert_falls_back_to_bencode(
+        self, tmp_path, monkeypatch
+    ):
+        """Old libtorrent builds expose ``alert.resume_data`` + bencode
+        instead of ``alert.params`` + ``write_resume_data_buf``."""
+        adapter, fake_lt, _ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        # Strip the modern API to force the fallback path.
+        del fake_lt.write_resume_data_buf
+
+        handle = SimpleNamespace(info_hash=lambda: "b" * 40)
+        alert = SimpleNamespace(
+            handle=handle, params=None, resume_data={"libtorrent": "entry"}
+        )
+        adapter._persist_resume_alert(alert)
+
+        out = os.path.join(adapter._resume_data_dir, ("b" * 40) + ".fastresume")
+        assert os.path.isfile(out)
+        with open(out, "rb") as f:
+            assert f.read().startswith(b"BENC|")
+
+    def test_persist_resume_alert_skips_when_no_dir(
+        self, tmp_path, monkeypatch
+    ):
+        adapter, fake_lt, _ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        adapter._resume_data_dir = None
+        handle = SimpleNamespace(info_hash=lambda: "c" * 40)
+        alert = SimpleNamespace(handle=handle, params=b"x", resume_data=None)
+        # Must not raise; just silently no-op.
+        adapter._persist_resume_alert(alert)
+
+    def test_delete_resume_file_idempotent(self, tmp_path, monkeypatch):
+        adapter, *_ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        path = os.path.join(adapter._resume_data_dir, ("d" * 40) + ".fastresume")
+        with open(path, "wb") as f:
+            f.write(b"x")
+        adapter._delete_resume_file("d" * 40)
+        assert not os.path.exists(path)
+        # Calling again is a no-op rather than an error.
+        adapter._delete_resume_file("d" * 40)
+
+    def test_load_resume_data_dir_readds_each_blob(
+        self, tmp_path, monkeypatch
+    ):
+        adapter, fake_lt, _ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        # Two valid resume files plus a junk filename that must be skipped.
+        good_a = "1" * 40
+        good_b = "2" * 40
+        for name, payload in (
+            (good_a + ".fastresume", b"AAA"),
+            (good_b + ".fastresume", b"BBB"),
+            ("not-a-hash.fastresume", b"ignored"),
+        ):
+            with open(os.path.join(adapter._resume_data_dir, name), "wb") as f:
+                f.write(payload)
+
+        # The session's add_torrent must return a handle whose info_hash
+        # reflects the blob so the adapter can map it back.
+        added: list[bytes] = []
+
+        class _Handle:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def info_hash(self):
+                if self._payload == b"AAA":
+                    return good_a
+                if self._payload == b"BBB":
+                    return good_b
+                return "x" * 40
+
+        def fake_add_torrent(params):
+            added.append(params.resume_data)
+            return _Handle(params.resume_data)
+
+        adapter.session.add_torrent.side_effect = fake_add_torrent
+        adapter._load_resume_data_dir()
+        # Only the two well-named files should have been re-added.
+        assert sorted(added) == [b"AAA", b"BBB"]
+        # And both handles registered for live polling.
+        assert good_a in adapter.handles
+        assert good_b in adapter.handles
+
+    def test_load_resume_data_dir_swallows_io_errors(
+        self, tmp_path, monkeypatch
+    ):
+        adapter, fake_lt, _ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        bad = "3" * 40 + ".fastresume"
+        with open(os.path.join(adapter._resume_data_dir, bad), "wb") as f:
+            f.write(b"GARBAGE")
+
+        # First call works (we get a handle); the second blob raises.
+        def boom(blob):
+            raise RuntimeError("corrupt fastresume")
+
+        fake_lt.read_resume_data = boom
+        # Must not propagate.
+        adapter._load_resume_data_dir()
+
+    def test_periodic_save_throttles_to_interval(
+        self, tmp_path, monkeypatch
+    ):
+        adapter, *_ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        handle = MagicMock()
+        handle.is_valid.return_value = True
+        handle.has_metadata.return_value = True
+        adapter.handles = {"h": handle}
+
+        # First call requests resume data; second call (immediately
+        # after) is throttled so we don't flood the alert queue.
+        adapter._maybe_request_periodic_resume_save()
+        adapter._maybe_request_periodic_resume_save()
+        assert handle.save_resume_data.call_count == 1
+
+
+class TestResumeDataBlob:
+    def test_blob_prefers_modern_api(self, tmp_path, monkeypatch):
+        adapter, fake_lt, _ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        alert = SimpleNamespace(params=b"PAYLOAD", resume_data=None)
+        assert adapter._resume_data_blob(alert) == b"PAYLOAD"
+
+    def test_blob_returns_none_when_no_api_available(
+        self, tmp_path, monkeypatch
+    ):
+        adapter, fake_lt, _ = _make_libtorrent_adapter(tmp_path, monkeypatch)
+        del fake_lt.write_resume_data_buf
+        del fake_lt.bencode
+        alert = SimpleNamespace(params=None, resume_data=None)
+        assert adapter._resume_data_blob(alert) is None


### PR DESCRIPTION
## Summary
- Strengthens libtorrent session handling and download manager orchestration.
- Adds unit coverage for restore paths and fast-resume behavior.

Stacked on #2.

## Test plan
- [ ] `pytest tests/unit/components/test_download_manager_edges.py tests/unit/torrent_managers/test_libtorrent_fastresume.py`

## Summary by Sourcery

Improve torrent session resilience and persisted state restore for LibTorrent-backed downloads, including fast-resume support and safer shutdown/startup flows.

New Features:
- Persist and reload LibTorrent fast-resume checkpoints on disk so interrupted torrents resume without full rechecks.
- Restore persisted torrents into a fresh LibTorrent session by re-queuing database-backed magnets on startup.

Bug Fixes:
- Avoid losing torrent progress or seeding state on clean shutdown by draining resume-data alerts before tearing down the LibTorrent session.
- Correctly decode persisted tracker lists so regenerated magnet links preserve all trackers instead of treating JSON as a character stream.
- Ensure redownload requests and persisted restores do not enqueue duplicate torrents for the same anime/hash.
- Prevent blocking shutdown in the persistence queue when draining is disabled. 

Enhancements:
- Harden the LibTorrent alert loop with metadata-aware resume-data requests, periodic checkpointing, and robust error handling.
- Align DownloadManager’s restore logic with LibTorrent’s ephemeral sessions using guarded, idempotent background restore passes.
- Improve anime folder resolution on restore by preferring existing per-anime directories that already hold media.
- Initialize torrent search UI with richer title variants for better default queries.
- Simplify DownloadManager’s integration with legacy entities via the new bridges module import.

Tests:
- Add extensive unit coverage for LibTorrent fast-resume persistence, loading, and periodic checkpoint behavior without requiring a real libtorrent install.
- Expand DownloadManager edge-case tests for persisted restore flows, redownload behavior, tracker decoding, folder selection, and watching-tag callbacks.
- Add a regression test ensuring the persistence queue can stop without draining and remains safely idempotent.