### PR TITLE
feat: stable /ui/api JSON endpoints and legacy web UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ See [`docs/developer/architecture.rst`](docs/developer/architecture.rst)
 for the long-form description and [`clients/README.md`](clients/README.md)
 for client-adapter guidance.
 
+### Refactor stability gate
+
+During the stability refactor program, run before merging metadata or
+architecture changes::
+
+    python scripts/stability_gate.py
+
+See [`docs/developer/stability-slos.rst`](docs/developer/stability-slos.rst)
+and [ADR 0007](docs/adr/0007-stability-refactor.md).
+
 ## Features
 
 * Multi-provider anime metadata (Kitsu, AniList, MyAnimeList, Jikan).
@@ -116,6 +126,29 @@ Browsers hitting `/` are redirected to `/ui/library`; API tooling
 still receives the JSON status payload at `/`. See
 [`docs/features/web_ui.rst`](docs/features/web_ui.rst) for the full
 route map and design notes.
+
+### Next.js web UI (cutover target)
+
+The new App Router frontend lives in `next-web/` and consumes Python
+JSON/SSE/WS endpoints.
+
+```bash
+cd next-web
+cp .env.example .env.local
+npm install
+npm run dev
+```
+
+To redirect legacy `/ui/*` HTML routes to the Next.js app during
+cutover, set:
+
+```bash
+ANIMEMANAGER_NEXT_UI_URL=http://127.0.0.1:3000
+```
+
+Realtime endpoints (`/ui/library/ws`, `/ui/downloads/ws`,
+`/ui/anime/{id}/torrents/stream`, `/ui/logs/stream`) remain served by
+the Python backend.
 
 ### Convenience launcher (Windows)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -7,13 +7,14 @@ handler below; they do not get their own ``__main__.py``.
 
 Modes
 -----
-``gui``
-    Launch the embedded Tk client adapter
-    (``clients.tk.run``). Default.
 ``api``
     Launch the FastAPI / Uvicorn HTTP client adapter
-    (``clients.http.app:app``). The HTTP runtime is a peer client of
-    the embedded backend per ADR 0001, not a privileged layer.
+    (``clients.http.app:app``), including the server-rendered web UI.
+    Default.
+``gui``
+    Launch the embedded Tk client adapter (``clients.tk.run``).
+    The HTTP runtime is a peer client of the embedded backend per
+    ADR 0001, not a privileged layer.
 """
 
 from __future__ import annotations
@@ -80,6 +81,18 @@ def _run_gui() -> int:
     return 0
 
 
+def _http_app_import_target() -> tuple[object, str]:
+    """Import the FastAPI app and return (app, uvicorn module path)."""
+    try:
+        from AnimeManager.clients.http.app import app  # type: ignore
+
+        return app, "AnimeManager.clients.http.app:app"
+    except ImportError:
+        from clients.http.app import app
+
+        return app, "clients.http.app:app"
+
+
 def _run_api(host: str = "0.0.0.0", port: int = 8081) -> int:
     """Launch the HTTP client adapter via uvicorn."""
     try:
@@ -93,14 +106,14 @@ def _run_api(host: str = "0.0.0.0", port: int = 8081) -> int:
         return 2
 
     try:
-        from clients.http.app import app  # noqa: F401  (import check only)
+        _app, app_target = _http_app_import_target()
     except ImportError as exc:
         _LOG.error("HTTP client adapter unavailable: %s", exc)
         return 2
 
     _kickoff_startup_jobs()
     uvicorn.run(
-        "clients.http.app:app",
+        app_target,
         host=host,
         port=port,
         timeout_graceful_shutdown=8,
@@ -121,7 +134,7 @@ def list_modes() -> Dict[str, Callable[..., int]]:
     return dict(_MODES)
 
 
-def main(mode: str = "gui", **kwargs) -> int:
+def main(mode: str = "api", **kwargs) -> int:
     """Dispatch to the requested runtime mode.
 
     Parameters

--- a/clients/http/app.py
+++ b/clients/http/app.py
@@ -19,7 +19,7 @@ import logging
 from contextlib import asynccontextmanager
 from functools import lru_cache
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Body, FastAPI, HTTPException, Request
 from fastapi.responses import RedirectResponse
 
 try:
@@ -115,6 +115,322 @@ def root(request: Request):
     if "text/html" in accept:
         return RedirectResponse("/ui/library", status_code=307)
     return {"service": "animemanager-http-client-adapter", "status": "ok"}
+
+
+@app.get("/ui/api/meta")
+def ui_api_meta():
+    """Expose stable backend capabilities consumed by Next.js UI."""
+    return {
+        "service": "animemanager-http-client-adapter",
+        "ui_api_version": "2026-05-18",
+        "streams": {
+            "library_ws": "/ui/library/ws",
+            "downloads_ws": "/ui/downloads/ws",
+            "torrent_sse": "/ui/anime/{anime_id}/torrents/stream",
+            "logs_sse": "/ui/logs/stream",
+        },
+    }
+
+
+@app.get("/ui/api/config")
+def ui_api_config():
+    """Static UI configuration shared with the legacy web templates."""
+    return {
+        "filter_options": _web.FILTER_OPTIONS,
+        "page_size": _web.PAGE_SIZE,
+        "torrent_result_limit": _web.TORRENT_RESULT_LIMIT,
+    }
+
+
+@app.get("/ui/api/library")
+def ui_api_library(
+    q: str | None = None,
+    filter: str = "DEFAULT",
+    page: int = 1,
+    list_start: int | None = None,
+    list_stop: int | None = None,
+    hide_rated: bool | None = None,
+):
+    """Library payload for Next.js pages.
+
+    When ``q`` is non-empty, this returns search-mode results.
+    Otherwise it mirrors the filter/list pagination payload.
+    """
+    try:
+        sdk = get_sdk()
+        query = (q or "").strip()
+        page_num = max(1, int(page))
+        page_size = _web.PAGE_SIZE
+        start = list_start if list_start is not None else (page_num - 1) * page_size
+        stop = list_stop if list_stop is not None else start + page_size
+        if query:
+            items = sdk.search_anime(query=query, limit=max(1, stop - start))
+            return {
+                "mode": "search",
+                "query": query,
+                "items": items,
+                "has_next": False,
+                "list_start": start,
+                "list_stop": stop,
+                "page": page_num,
+                "page_size": page_size,
+                "filter": filter,
+                "streaming_search": len(query) >= 3,
+                "search_ws_path": "/ui/library/ws",
+            }
+        listing = sdk.get_anime_list(
+            filter_name=filter,
+            list_start=start,
+            list_stop=stop,
+            hide_rated=hide_rated,
+        )
+        return {
+            "mode": "list",
+            "query": "",
+            "items": listing.get("items", []),
+            "has_next": bool(listing.get("has_next")),
+            "list_start": start,
+            "list_stop": stop,
+            "page": page_num,
+            "page_size": page_size,
+            "filter": filter,
+            "streaming_search": False,
+            "search_ws_path": "",
+        }
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/anime/{anime_id}/bundle")
+def ui_api_anime_bundle(
+    anime_id: int,
+    user_id: int = 1,
+):
+    """Aggregate anime detail payload for Next.js detail/watch pages."""
+    try:
+        sdk = get_sdk()
+        anime = sdk.get_anime(anime_id)
+        state = sdk.get_user_state(anime_id, user_id)
+        terms = sdk.get_search_terms(anime_id)
+        episodes = sdk.list_episode_files(anime_id, user_id=user_id)
+        relations = sdk.get_relations(anime_id)
+        characters = sdk.list_anime_characters(anime_id)
+        display = _web.anime_detail_display_for_api(
+            sdk,
+            anime_id,
+            anime=anime if isinstance(anime, dict) else None,
+            terms=list(terms or []),
+        )
+        return {
+            "anime": anime,
+            "state": state,
+            "search_terms": terms,
+            "episodes": episodes,
+            "relations": display.get("relations", relations),
+            "characters": characters,
+            "last_torrent_query": sdk.get_last_torrent_search_query(anime_id) or "",
+            **display,
+        }
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/anime/{anime_id}/watch")
+def ui_api_anime_watch(
+    anime_id: int,
+    file_id: str = "",
+    user_id: int = 1,
+):
+    try:
+        return _web.watch_context_for_api(
+            get_sdk(),
+            anime_id,
+            file_id=file_id,
+            user_id=user_id,
+        )
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/settings")
+def ui_api_settings():
+    try:
+        from . import settings_form
+
+        current = get_sdk().get_settings() or {}
+        return {
+            "settings": current,
+            "sections": settings_form.build_sections(current),
+        }
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/logs/page")
+def ui_api_logs_page(
+    request: Request,
+    level: str = "",
+    logger: str | None = None,
+    q: str | None = None,
+):
+    """Logs page snapshot for Next.js (mirrors ``web_logs`` context)."""
+    try:
+        _web._sync_log_buffer_from_settings_safe()
+        min_level, logger_substr, text = _web._parse_log_filters(level, logger, q)
+        categories = _web._selected_categories(request)
+        records = _web.log_buffer.global_buffer.snapshot(
+            min_level=min_level,
+            logger_substr=logger_substr,
+            text=text,
+            categories=categories or None,
+            limit=_web.LOG_TAIL_INITIAL,
+        )
+        last_id = records[-1]["id"] if records else 0
+        total_in_buffer = len(_web.log_buffer.global_buffer.snapshot())
+        known_cats = _web.log_buffer.global_buffer.known_categories()
+        disabled_cats = _web.log_buffer.global_buffer.disabled_categories
+        selected_set = set(categories)
+        category_chips = [
+            {
+                "name": cat,
+                "active": cat in selected_set,
+                "disabled_in_settings": cat in disabled_cats,
+            }
+            for cat in known_cats
+        ]
+        return {
+            "records": records,
+            "last_id": last_id,
+            "active_filter_level": (level or "").upper(),
+            "active_filter_logger": logger or "",
+            "active_filter_q": q or "",
+            "active_filter_categories": list(categories),
+            "level_choices": _web.LOG_LEVEL_CHOICES,
+            "category_chips": category_chips,
+            "total_in_buffer": total_in_buffer,
+        }
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/anime/{anime_id}/characters")
+def ui_api_anime_characters(anime_id: int):
+    try:
+        return {"items": get_sdk().list_anime_characters(anime_id)}
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/anime/{anime_id}/episodes")
+def ui_api_anime_episodes(anime_id: int, user_id: int = 1):
+    try:
+        return {"items": get_sdk().list_episode_files(anime_id, user_id=user_id)}
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/torrents/search")
+def ui_api_torrent_search(
+    anime_id: int | None = None,
+    term: str = "",
+    profile: str = "interactive",
+    limit: int = 200,
+):
+    """Search torrents using the same contract as Next.js torrent views."""
+    query = term.strip()
+    if not query and anime_id is not None:
+        query = get_sdk().get_last_torrent_search_query(anime_id) or ""
+    terms = [part.strip() for part in query.split(",") if part.strip()]
+    try:
+        raw = get_sdk().search_torrents(terms=terms, profile=profile, limit=limit)
+        items = _web._normalize_torrents(raw)
+        if anime_id is not None and query:
+            get_sdk().set_last_torrent_search_query(anime_id, query)
+        return {"query": query, "items": items}
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/downloads/overview")
+def ui_api_downloads_overview():
+    try:
+        overview = get_sdk().get_torrents_overview()
+        counts = {key: len(overview.get(key) or []) for key in overview.keys()}
+        return {"overview": overview, "counts": counts}
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.get("/ui/api/logs")
+def ui_api_logs(
+    level: str = "INFO",
+    logger: str = "",
+    q: str = "",
+    limit: int = 200,
+    since: int = 0,
+):
+    """Read a JSON slice of buffered logs for Next.js log page."""
+    min_level, logger_substr, text = _web._parse_log_filters(level, logger, q)
+    snap = _web.log_buffer.global_buffer.snapshot(
+        min_level=min_level,
+        logger_substr=logger_substr,
+        text=text,
+        categories=None,
+    )
+    if since:
+        snap = [r for r in snap if int(r.get("id") or 0) > int(since)]
+    if limit and limit > 0:
+        snap = snap[-limit:]
+    return {
+        "records": snap,
+        "last_id": snap[-1]["id"] if snap else since,
+        "buffered": len(_web.log_buffer.global_buffer.snapshot()),
+    }
+
+
+@app.post("/ui/api/anime/{anime_id}/like")
+def ui_api_like_anime(anime_id: int, payload: dict = Body(default={})):
+    try:
+        user_id = int(payload.get("user_id", 1))
+        liked = bool(payload.get("liked", True))
+        get_sdk().set_like(anime_id, user_id=user_id, liked=liked)
+        return {"ok": True}
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.post("/ui/api/anime/{anime_id}/tag")
+def ui_api_tag_anime(anime_id: int, payload: dict = Body(default={})):
+    try:
+        user_id = int(payload.get("user_id", 1))
+        tag = str(payload.get("tag", "")).strip()
+        get_sdk().set_tag(anime_id, tag=tag, user_id=user_id)
+        return {"ok": True, "tag": tag}
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.post("/ui/api/anime/{anime_id}/download")
+def ui_api_download_anime(anime_id: int, payload: dict = Body(default={})):
+    try:
+        return {
+            "started": get_sdk().start_download(
+                anime_id,
+                url=payload.get("url"),
+                hash_value=payload.get("hash"),
+                user_id=int(payload.get("user_id", 1)),
+            )
+        }
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
+
+
+@app.post("/ui/api/anime/{anime_id}/cancel")
+def ui_api_cancel_anime_download(anime_id: int):
+    try:
+        return {"cancelled": bool(get_sdk().cancel_download(anime_id))}
+    except Exception as exc:  # pragma: no cover
+        raise _map_error(exc) from exc
 
 
 @app.get("/anime/{anime_id}")

--- a/clients/http/static/css/app.css
+++ b/clients/http/static/css/app.css
@@ -866,22 +866,115 @@ textarea {
 
 .detail__synonyms {
   font-size: 14px;
+  line-height: 1.45;
   color: var(--text-muted);
+  max-width: 65ch;
 }
 
-.detail__stats {
+.detail__stats,
+.detail__badges {
   display: flex;
   flex-wrap: wrap;
   gap: var(--sp-2);
+}
+
+.detail__stats {
   margin-top: var(--sp-3);
 }
 
+.detail__badges {
+  margin-top: var(--sp-2);
+}
+
 .detail__synopsis {
-  margin-top: var(--sp-6);
+  margin-top: var(--sp-5);
   font-size: 16px;
   line-height: 1.65;
   color: var(--text);
   max-width: 70ch;
+}
+
+.detail__synopsis--empty {
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+.detail__info {
+  margin-top: var(--sp-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  max-width: 72ch;
+}
+
+.detail__info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--sp-3);
+}
+
+.detail__info-card {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  padding: var(--sp-4);
+}
+
+.detail__info-card--genres {
+  margin-top: var(--sp-1);
+}
+
+.detail__info-label {
+  margin: 0 0 var(--sp-3);
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.detail__info-card-body {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-2);
+}
+
+.detail__kv {
+  display: grid;
+  grid-template-columns: minmax(96px, 38%) minmax(0, 1fr);
+  gap: var(--sp-3) var(--sp-4);
+  margin: 0;
+}
+
+.detail__kv dt {
+  margin: 0;
+  color: var(--text-faint);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.detail__kv dd {
+  margin: 0;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.detail__kv-hint {
+  display: block;
+  margin-top: var(--sp-1);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.detail__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
 }
 
 .detail__actions {
@@ -889,6 +982,48 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   gap: var(--sp-2);
+}
+
+.episode-row-menu {
+  position: relative;
+  display: inline-block;
+}
+
+.episode-row-menu__panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 40;
+  min-width: 168px;
+  padding: var(--sp-1);
+  border-radius: var(--r-2);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  box-shadow: var(--shadow-2);
+}
+
+.episode-row-menu__item {
+  display: block;
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  border: 0;
+  border-radius: var(--r-1);
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.episode-row-menu__item:hover,
+.episode-row-menu__item:focus-visible {
+  background: var(--surface-3);
+  outline: none;
+}
+
+.episode-row-menu__item--danger {
+  color: var(--danger);
 }
 
 .detail__section {
@@ -975,6 +1110,17 @@ textarea {
 
 .watch-view__video-wrap {
   min-height: 68vh;
+  position: relative;
+}
+
+.watch-view__page-nav {
+  position: sticky;
+  top: calc(var(--topbar-h) + var(--safe-top));
+  z-index: 25;
+  margin: 0 0 var(--sp-4);
+  padding: var(--sp-2) 0 var(--sp-3);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
 }
 
 .watch-view__controller {
@@ -989,6 +1135,8 @@ textarea {
   width: 100%;
   min-height: 68vh;
   max-height: 80vh;
+  object-fit: contain;
+  object-position: center center;
 }
 
 .watch-view__controller:fullscreen,
@@ -996,17 +1144,51 @@ textarea {
   width: 100vw;
   height: 100vh;
   min-height: 100vh;
+  --media-width: 100vw;
+  --media-height: 100vh;
+  --media-object-fit: contain;
+}
+
+.watch-view__video-wrap:fullscreen,
+.watch-view__video-wrap:-webkit-full-screen {
+  width: 100vw;
+  height: 100vh;
+  min-height: 100vh;
+  background: #000;
+  overflow: visible;
+}
+
+.watch-view__video-wrap:fullscreen .watch-view__controller,
+.watch-view__video-wrap:-webkit-full-screen .watch-view__controller {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+}
+
+.watch-view__video-wrap:fullscreen .watch-view__ass-overlay,
+.watch-view__video-wrap:-webkit-full-screen .watch-view__ass-overlay {
+  inset: 0;
+  z-index: 12;
+}
+
+.watch-view__video-wrap:fullscreen .player-panel__status,
+.watch-view__video-wrap:-webkit-full-screen .player-panel__status {
+  display: none;
 }
 
 .watch-view__controller:fullscreen .watch-view__video,
 .watch-view__controller:-webkit-full-screen .watch-view__video,
+.watch-view__video-wrap:fullscreen .watch-view__video,
+.watch-view__video-wrap:-webkit-full-screen .watch-view__video,
 .watch-view__video:fullscreen,
 .watch-view__video:-webkit-full-screen {
-  width: 100%;
-  height: 100%;
-  min-height: 100%;
-  max-height: none;
-  object-fit: contain;
+  width: 100vw !important;
+  height: 100vh !important;
+  min-height: 100vh !important;
+  max-height: none !important;
+  /* Preserve source display aspect ratio on non-standard displays. */
+  object-fit: contain !important;
+  object-position: center center !important;
   background: #000;
 }
 
@@ -1017,8 +1199,11 @@ textarea {
  */
 .watch-view__controller .shaka-text-container {
   position: absolute;
-  inset: 0;
-  z-index: 2;
+  left: var(--am-video-box-left, 0px);
+  top: var(--am-video-box-top, 0px);
+  width: var(--am-video-box-width, 100%);
+  height: var(--am-video-box-height, 100%);
+  z-index: 8;
   pointer-events: none;
   padding: 0 2.5% calc(4% + env(safe-area-inset-bottom, 0px));
   box-sizing: border-box;
@@ -1030,10 +1215,21 @@ textarea {
   max-width: 96%;
 }
 
-.watch-view__controller .libassjs-canvas-parent {
+.watch-view__ass-overlay {
   position: absolute;
   inset: 0;
-  z-index: 4;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.watch-view__controller .libassjs-canvas-parent,
+.watch-view__ass-overlay .libassjs-canvas-parent {
+  position: absolute;
+  left: var(--am-video-box-left, 0px);
+  top: var(--am-video-box-top, 0px);
+  width: var(--am-video-box-width, 100%);
+  height: var(--am-video-box-height, 100%);
+  z-index: 11;
   pointer-events: none;
   display: flex;
   align-items: stretch;
@@ -1610,6 +1806,39 @@ tr:hover .torrent-name::after,
   );
   border-radius: var(--r-full);
   transition: width 240ms ease;
+}
+
+.progress--watch {
+  min-width: 140px;
+}
+
+.progress--watch .progress__bar {
+  background: linear-gradient(
+    90deg,
+    var(--accent) 0%,
+    rgba(86, 216, 239, 0.75) 100%
+  );
+}
+
+.progress--watch-high .progress__bar {
+  background: linear-gradient(
+    90deg,
+    var(--success) 0%,
+    #7ec020 100%
+  );
+}
+
+.episode-watch-meta {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.episode-watch-meta--muted {
+  color: var(--text-faint);
 }
 
 .download-card {
@@ -2635,6 +2864,14 @@ tr:hover .torrent-name::after,
     font-size: 14.5px;
   }
 
+  .detail__info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail__kv {
+    grid-template-columns: minmax(88px, 42%) minmax(0, 1fr);
+  }
+
   /* Cards: tighter grid on phones. */
   .grid {
     grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
@@ -2775,17 +3012,24 @@ tr:hover .torrent-name::after,
 /* Anime detail page tables should keep all columns visible in the
  * viewport while still giving the key text columns ("Episode" and
  * "Release") extra room whenever the container is wide enough. */
-.table-wrap > .table--anime-episodes,
+.table-wrap > .table--anime-episodes {
+  /* Progress select + action buttons need stable width; let table scroll
+   * horizontally on narrower viewports instead of overlapping columns. */
+  min-width: 860px;
+  table-layout: auto;
+}
+
 .table-wrap > .table--anime-downloads {
   min-width: 0;
   table-layout: fixed;
 }
 
-.table--anime-episodes .col--episode-file { width: 34%; }
-.table--anime-episodes .col--season       { width: 10%; }
-.table--anime-episodes .col--episode      { width: 28%; }
-.table--anime-episodes .col--size         { width: 14%; }
-.table--anime-episodes .col--actions      { width: 14%; }
+.table--anime-episodes .col--episode-file { width: auto; }
+.table--anime-episodes .col--season       { width: 72px; }
+.table--anime-episodes .col--episode      { width: 72px; }
+.table--anime-episodes .col--size         { width: 112px; }
+.table--anime-episodes .col--progress     { width: 196px; }
+.table--anime-episodes .col--actions      { width: 176px; }
 
 .table--anime-downloads .col--release     { width: 56%; }
 .table--anime-downloads .col--size        { width: 12%; }

--- a/clients/http/static/js/app.js
+++ b/clients/http/static/js/app.js
@@ -16,10 +16,13 @@
   document.addEventListener("DOMContentLoaded", () => {
     wireAutoSubmit();
     wireConfirmGuards();
+    wireCopyButtons();
+    wireTorrentDownloadForms();
     wireRelativeTimes();
     wireSearchDebounce();
     wireTrailerModal();
     wireEpisodePlayer(document);
+    wireEpisodeRowMenus(document);
     wireTorrentTermModal();
     wireScrollAnchors();
     wireTableSort(document);
@@ -41,11 +44,13 @@
   // anything that needs activation (e.g. SSE consumers in the inline
   // torrent search partial) every time a fragment lands.
   document.body && document.body.addEventListener("htmx:afterSwap", (ev) => {
+    wireCopyButtons();
     wireTableSort(ev.target || document);
     wireTablePagination(ev.target || document);
     wireTorrentFilters(ev.target || document);
     wireTorrentStreams(ev.target || document);
     wireEpisodePlayer(ev.target || document);
+    wireEpisodeRowMenus(ev.target || document);
     wireLogConsole(ev.target || document);
     wireDownloadsWebsocket(ev.target || document);
     wireLibrarySearchStream(ev.target || document);
@@ -75,6 +80,145 @@
           ev.stopImmediatePropagation();
         }
       });
+    });
+  }
+
+  function wireEpisodeRowMenus(root) {
+    const scope = root && root.querySelectorAll ? root : document;
+    $$("[data-episode-menu]", scope).forEach((menu) => {
+      if (menu.dataset.episodeMenuWired === "1") return;
+      menu.dataset.episodeMenuWired = "1";
+      const toggle = menu.querySelector("[data-episode-menu-toggle]");
+      const panel = menu.querySelector("[data-episode-menu-panel]");
+      if (!toggle || !panel) return;
+
+      const close = () => {
+        panel.hidden = true;
+        toggle.setAttribute("aria-expanded", "false");
+      };
+
+      const open = () => {
+        $$("[data-episode-menu-panel]").forEach((other) => {
+          if (other === panel) return;
+          other.hidden = true;
+          const otherToggle = other
+            .closest("[data-episode-menu]")
+            ?.querySelector("[data-episode-menu-toggle]");
+          if (otherToggle) otherToggle.setAttribute("aria-expanded", "false");
+        });
+        panel.hidden = false;
+        toggle.setAttribute("aria-expanded", "true");
+      };
+
+      toggle.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        if (panel.hidden) open();
+        else close();
+      });
+
+      panel.addEventListener("click", (ev) => {
+        const target = ev.target;
+        if (!(target instanceof Element)) return;
+        if (target.closest("form") || target.matches("a[href]")) {
+          close();
+        }
+      });
+    });
+
+    if (!document.documentElement.dataset.episodeMenuDocWired) {
+      document.documentElement.dataset.episodeMenuDocWired = "1";
+      document.addEventListener("click", (ev) => {
+        const target = ev.target;
+        if (!(target instanceof Element)) return;
+        if (target.closest("[data-episode-menu]")) return;
+        $$("[data-episode-menu-panel]").forEach((panel) => {
+          panel.hidden = true;
+          const toggle = panel
+            .closest("[data-episode-menu]")
+            ?.querySelector("[data-episode-menu-toggle]");
+          if (toggle) toggle.setAttribute("aria-expanded", "false");
+        });
+      });
+      document.addEventListener("keydown", (ev) => {
+        if (ev.key !== "Escape") return;
+        $$("[data-episode-menu-panel]").forEach((panel) => {
+          panel.hidden = true;
+          const toggle = panel
+            .closest("[data-episode-menu]")
+            ?.querySelector("[data-episode-menu-toggle]");
+          if (toggle) toggle.setAttribute("aria-expanded", "false");
+        });
+      });
+    }
+  }
+
+  function wireCopyButtons() {
+    $$("[data-copy-text]").forEach((el) => {
+      if (el.dataset.copyWired === "1") return;
+      el.dataset.copyWired = "1";
+      el.addEventListener("click", async () => {
+        const text = el.getAttribute("data-copy-text") || "";
+        if (!text.trim()) return;
+        try {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(text);
+            return;
+          }
+        } catch (_) {
+          // Fallback below.
+        }
+        const input = document.createElement("input");
+        input.value = text;
+        document.body.appendChild(input);
+        input.select();
+        try {
+          document.execCommand("copy");
+        } catch (_) {
+          // ignore fallback errors
+        }
+        input.remove();
+      });
+    });
+  }
+
+  function wireTorrentDownloadForms() {
+    if (document.documentElement.dataset.torrentDownloadWired === "1") return;
+    document.documentElement.dataset.torrentDownloadWired = "1";
+
+    document.addEventListener("submit", async (ev) => {
+      const form =
+        ev.target && ev.target.closest
+          ? ev.target.closest("[data-torrent-download-form]")
+          : null;
+      if (!form) return;
+
+      ev.preventDefault();
+      const submitBtn = form.querySelector("[data-torrent-download-button]");
+      if (submitBtn && submitBtn.disabled) return;
+
+      const originalLabel = submitBtn ? submitBtn.textContent : "";
+      if (submitBtn) {
+        submitBtn.disabled = true;
+        submitBtn.textContent = "Queuing...";
+      }
+
+      try {
+        const res = await fetch(form.action, {
+          method: "POST",
+          body: new FormData(form),
+          credentials: "same-origin",
+          redirect: "follow",
+          headers: { "X-Requested-With": "fetch" },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (submitBtn) submitBtn.textContent = "Queued";
+      } catch (_) {
+        if (submitBtn) {
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalLabel || "Download";
+        }
+      }
     });
   }
 
@@ -185,10 +329,22 @@
     const animeId = panel.getAttribute("data-play-anime-id") || "";
     const controller = panel.querySelector("media-controller");
     const video = panel.querySelector("[data-player-video]");
+    const videoWrap = panel.querySelector(".player-panel__video-wrap");
+    const assOverlayHost =
+      panel && typeof panel.querySelector === "function"
+        ? panel.querySelector("[data-player-ass-overlay]")
+        : null;
+    const fullscreenHost =
+      videoWrap &&
+      videoWrap.contains(video) &&
+      (!assOverlayHost || videoWrap.contains(assOverlayHost))
+        ? videoWrap
+        : null;
+    const fallbackFullscreenHost =
+      videoWrap && videoWrap.contains(video) ? videoWrap : null;
     const status = panel.querySelector("[data-player-status]");
     const title = panel.querySelector("[data-player-title]");
     const error = panel.querySelector("[data-player-error]");
-    const fullscreenButton = panel.querySelector("media-fullscreen-button");
     const host = panel.closest("[data-player-host]") || panel;
     const autoFileId = panel.getAttribute("data-player-auto-file-id") || "";
     const autoFileTitle = panel.getAttribute("data-player-auto-file-title") || "";
@@ -211,6 +367,54 @@
     const episodeProgressUrl =
       panel.getAttribute("data-episode-progress-url") || "";
     if (!endpoint || !video) return;
+    const resolveFullscreenTarget = () => {
+      // Prefer a host that contains both media and ASS overlay so
+      // fullscreen never excludes the subtitle canvas tree.
+      const baseTarget = fullscreenHost || fallbackFullscreenHost || controller || video;
+      if (
+        assOverlayHost &&
+        baseTarget &&
+        typeof baseTarget.contains === "function" &&
+        baseTarget.contains(video) &&
+        baseTarget.contains(assOverlayHost)
+      ) {
+        return baseTarget;
+      }
+      const overlayWrap =
+        assOverlayHost && typeof assOverlayHost.closest === "function"
+          ? assOverlayHost.closest(".player-panel__video-wrap")
+          : null;
+      if (
+        overlayWrap &&
+        typeof overlayWrap.contains === "function" &&
+        overlayWrap.contains(video) &&
+        (!assOverlayHost || overlayWrap.contains(assOverlayHost))
+      ) {
+        return overlayWrap;
+      }
+      return baseTarget || null;
+    };
+    const normalizedFullscreenHost = resolveFullscreenTarget();
+    if (normalizedFullscreenHost && !normalizedFullscreenHost.id) {
+      normalizedFullscreenHost.id = `watch-wrap-${animeId || "player"}`;
+    }
+    if (controller) {
+      // Normalize fullscreen ownership to the wrapper that contains both
+      // media and ASS overlay hosts.
+      const controllerFsTarget = normalizedFullscreenHost || video;
+      if (controllerFsTarget && !controllerFsTarget.id) {
+        controllerFsTarget.id =
+          controllerFsTarget === video
+            ? `watch-video-${animeId || "player"}`
+            : `watch-wrap-${animeId || "player"}`;
+      }
+      controller.setAttribute("fullscreenelement", controllerFsTarget ? controllerFsTarget.id : "");
+      try {
+        controller.fullscreenElement = controllerFsTarget || null;
+      } catch (_) {
+        /* ignore */
+      }
+    }
 
     let shakaPlayer = null;
     let sessionId = "";
@@ -224,6 +428,10 @@
     let replayQueued = false;
     let subtitleTrackRefs = {};
     let subtitleAssById = {};
+    let subtitleTracksReady = false;
+    // ASS/libass overlay is enabled and mounted into a dedicated overlay
+    // layer so subtitle visibility is independent from toolbar fades.
+    const enableAdvancedAssOverlay = true;
 
     const setStatus = (text) => {
       if (status) status.textContent = text;
@@ -399,16 +607,39 @@
       );
     }
 
+    const loadScriptTag = (src) =>
+      new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = src;
+        script.async = true;
+        script.onload = () => resolve(window.shaka || null);
+        script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
+        document.head.appendChild(script);
+      });
+
     const loadShakaScript = () => {
       if (window.shaka && window.shaka.Player) return Promise.resolve(window.shaka);
       if (window.__animeManagerShakaPromise) return window.__animeManagerShakaPromise;
-      window.__animeManagerShakaPromise = new Promise((resolve, reject) => {
-        const script = document.createElement("script");
-        script.src = "https://cdnjs.cloudflare.com/ajax/libs/shaka-player/4.10.9/shaka-player.compiled.min.js";
-        script.async = true;
-        script.onload = () => resolve(window.shaka || null);
-        script.onerror = () => reject(new Error("Could not load Shaka playback engine."));
-        document.head.appendChild(script);
+      window.__animeManagerShakaPromise = (async () => {
+        const localSrc = "/ui/static/vendor/shaka-player/shaka-player.compiled.min.js";
+        // Keep CDN fallback aligned with the vendored build. 4.16.13+ includes
+        // fixes for external WebVTT timing with HLS (MPEG-TS), which older
+        // 4.10.x builds mishandled so sidecar subtitles never registered.
+        const cdnSrc =
+          "https://cdn.jsdelivr.net/npm/shaka-player@4.16.13/dist/shaka-player.compiled.min.js";
+        try {
+          return await loadScriptTag(localSrc);
+        } catch (localErr) {
+          playerLog("warn", "shaka_local_load_failed", {
+            source: localSrc,
+            message: localErr && localErr.message ? localErr.message : String(localErr || ""),
+          });
+        }
+        return loadScriptTag(cdnSrc);
+      })().catch((err) => {
+        throw new Error(
+          `Could not load Shaka playback engine. ${err && err.message ? err.message : ""}`.trim(),
+        );
       });
       return window.__animeManagerShakaPromise;
     };
@@ -430,6 +661,9 @@
         /* ignore */
       }
       shakaPlayer = null;
+      subtitleTrackRefs = {};
+      subtitleAssById = {};
+      subtitleTracksReady = false;
     };
 
     const stopSession = async () => {
@@ -479,6 +713,7 @@
         method: "POST",
         body: fd,
         credentials: "same-origin",
+        headers: { "X-AM-Player-Background": "true" },
       }).catch(() => {});
     };
 
@@ -603,6 +838,7 @@
         assUrl = "";
       }
       if (
+        enableAdvancedAssOverlay &&
         assUrl &&
         ams &&
         typeof ams.supportsLibass === "function" &&
@@ -610,6 +846,10 @@
         typeof ams.startLibassOctopus === "function"
       ) {
         disposeAss();
+        const overlayRoot =
+          assOverlayHost && typeof assOverlayHost.appendChild === "function"
+            ? assOverlayHost
+            : null;
         panel.__amLibassOctopus = ams.startLibassOctopus(video, assUrl, (err) => {
           playerLog("error", "libass_init_failed", {
             message: err && err.message ? err.message : String(err || ""),
@@ -631,7 +871,7 @@
               setError("Could not switch subtitle track.");
             }
           }
-        });
+        }, { overlayRoot });
         if (panel.__amLibassOctopus) {
           if (bridge && typeof bridge.setAssBridgeActive === "function") {
             bridge.setAssBridgeActive(true);
@@ -654,6 +894,13 @@
       }
       const ref = subtitleTrackRefs[chosen];
       if (!ref) {
+        // Subtitle options can be selected while a new session is still
+        // buffering/loading and text tracks are being registered. Defer
+        // validation until registration completes to avoid false "unavailable" errors.
+        if (!subtitleTracksReady) {
+          setError("");
+          return;
+        }
         setError("Selected subtitle track is unavailable for this stream.");
         return;
       }
@@ -768,7 +1015,8 @@
         if (!shaka.Player.isBrowserSupported()) {
           throw new Error("This browser does not support adaptive streaming.");
         }
-        shakaPlayer = new shaka.Player(video);
+        shakaPlayer = new shaka.Player();
+        await shakaPlayer.attach(video);
         // Segments produced by seek-on-demand transcoding may take a
         // moment to materialise. Increase Shaka's retry budget so a
         // single transient 404 / slow restart doesn't tear down the
@@ -792,18 +1040,26 @@
                 fuzzFactor: 0.2,
                 timeout: 15000,
               },
+              // Default HLS sequenceMode ignores MPEG-TS PTS and infers the
+              // MSE timeline from #EXTINF order only. Our transcoder keeps
+              // absolute presentation timestamps (-copyts) aligned with the
+              // canonical playlist; after seeks / media-chrome skip buttons,
+              // sequence mode drifts from real media when EXTINF and actual
+              // segment lengths differ slightly.
+              hls: {
+                sequenceMode: false,
+              },
             },
           };
-          if (
-            window.AmPlaybackSubtitles &&
-            typeof window.AmPlaybackSubtitles.createShakaTextDisplayFactory === "function"
-          ) {
-            streamCfg.textDisplayFactory = window.AmPlaybackSubtitles.createShakaTextDisplayFactory();
-          }
           shakaPlayer.configure(streamCfg);
         } catch (_) {
           /* older Shaka builds may use a different config tree */
         }
+        // NOTE: Keep Shaka's default text displayer for stability.
+        // Our custom textDisplayFactory integration currently triggers
+        // argument-shape warnings on Shaka 4.10 and can destabilize
+        // startup on some browsers. We can re-enable a custom factory
+        // once the integration is aligned with the exact runtime API.
         shakaPlayer.addEventListener("error", (evt) => {
           const detail = evt && evt.detail ? evt.detail : {};
           const plain = shakaErrorToPlain(shaka, detail);
@@ -833,7 +1089,12 @@
         // offset, so the very first segment is the one near the
         // resume point. Tell Shaka to start there too. ``startTime``
         // is honoured by ``Player.load`` for both DASH and HLS.
+        playerLog("info", "manifest_load_start", {
+          manifest_url: manifestUrl || "",
+          resume_seconds: resumeSeconds || 0,
+        });
         await shakaPlayer.load(manifestUrl, resumeSeconds || null);
+        subtitleTracksReady = false;
         subtitleTrackRefs = {};
         subtitleAssById = {};
         for (const track of subtitleTracks) {
@@ -848,9 +1109,15 @@
             }
           }
           if (track.url == null) continue;
+          let vttUri = String(track.url);
+          try {
+            vttUri = new URL(vttUri, window.location.origin).href;
+          } catch (_) {
+            /* keep relative string */
+          }
           try {
             const ref = await shakaPlayer.addTextTrackAsync(
-              String(track.url),
+              vttUri,
               "und",
               "subtitles",
               "text/vtt",
@@ -858,10 +1125,15 @@
               String(track.label || `Subtitle ${trackId}`),
             );
             subtitleTrackRefs[trackId] = ref;
-          } catch (_) {
-            /* unsupported track / malformed VTT */
+          } catch (err) {
+            playerLog("warn", "subtitle_text_track_register_failed", {
+              track_id: trackId,
+              vtt_uri: vttUri,
+              message: err && err.message ? err.message : String(err || ""),
+            });
           }
         }
+        subtitleTracksReady = true;
         if (subtitleSelect) {
           applySubtitleSelection();
         }
@@ -995,10 +1267,142 @@
       emitAnalytics("buffering_ended", {});
     });
     video.addEventListener("seeking", () => emitAnalytics("seek_started", {}));
-    video.addEventListener("seeked", () => emitAnalytics("seek_completed", {}));
+    video.addEventListener("seeked", () => {
+      emitAnalytics("seek_completed", {});
+      const ams = window.AmPlaybackSubtitles;
+      if (
+        ams &&
+        typeof ams.syncOctopusToVideo === "function" &&
+        panel.__amLibassOctopus
+      ) {
+        try {
+          ams.syncOctopusToVideo(panel.__amLibassOctopus, video);
+        } catch (_) {
+          /* ignore */
+        }
+      }
+    });
 
     const fullscreenElement = () =>
       document.fullscreenElement || document.webkitFullscreenElement || null;
+    const enableFullscreenDiagnostics = true;
+    const describeElement = (el) => {
+      if (!el) return null;
+      return {
+        tag: el.tagName ? String(el.tagName).toLowerCase() : "",
+        id: el.id || "",
+        class_name: el.className ? String(el.className) : "",
+      };
+    };
+    const logFullscreenDiagnostics = (stage, extra) => {
+      if (!enableFullscreenDiagnostics) return;
+      const fsEl = fullscreenElement();
+      const inst = panel.__amLibassOctopus;
+      const canvasParent = inst && inst.canvasParent ? inst.canvasParent : null;
+      const canvasParentOwner = canvasParent && canvasParent.parentElement ? canvasParent.parentElement : null;
+      let canvasVisibility = "";
+      let canvasDisplay = "";
+      if (canvasParent && typeof window.getComputedStyle === "function") {
+        try {
+          const computed = window.getComputedStyle(canvasParent);
+          canvasVisibility = computed.visibility || "";
+          canvasDisplay = computed.display || "";
+        } catch (_) {
+          /* ignore */
+        }
+      }
+      playerLog("info", "fullscreen_diag_state", Object.assign({
+        stage: stage || "",
+        fullscreen_element: describeElement(fsEl),
+        normalized_host: describeElement(normalizedFullscreenHost),
+        normalized_host_contains_video: !!(
+          normalizedFullscreenHost &&
+          video &&
+          normalizedFullscreenHost.contains(video)
+        ),
+        normalized_host_contains_ass_overlay: !!(
+          normalizedFullscreenHost &&
+          assOverlayHost &&
+          normalizedFullscreenHost.contains(assOverlayHost)
+        ),
+        ass_overlay_host: describeElement(assOverlayHost),
+        libass_canvas_parent: describeElement(canvasParent),
+        libass_canvas_parent_owner: describeElement(canvasParentOwner),
+        libass_canvas_parent_in_normalized_host: !!(
+          normalizedFullscreenHost &&
+          canvasParent &&
+          normalizedFullscreenHost.contains(canvasParent)
+        ),
+        libass_canvas_parent_visibility: canvasVisibility,
+        libass_canvas_parent_display: canvasDisplay,
+      }, extra || {}));
+    };
+    const computeRenderedVideoBox = () => {
+      const container = controller || video;
+      if (!container) {
+        return { left: 0, top: 0, width: 0, height: 0 };
+      }
+      const containerWidth = Number(container.clientWidth || 0);
+      const containerHeight = Number(container.clientHeight || 0);
+      if (containerWidth <= 0 || containerHeight <= 0) {
+        return { left: 0, top: 0, width: 0, height: 0 };
+      }
+      const sourceWidth = Number(video.videoWidth || 0);
+      const sourceHeight = Number(video.videoHeight || 0);
+      if (sourceWidth <= 0 || sourceHeight <= 0) {
+        return { left: 0, top: 0, width: containerWidth, height: containerHeight };
+      }
+      const scale = Math.min(containerWidth / sourceWidth, containerHeight / sourceHeight);
+      const renderedWidth = Math.max(1, Math.round(sourceWidth * scale));
+      const renderedHeight = Math.max(1, Math.round(sourceHeight * scale));
+      const left = Math.round((containerWidth - renderedWidth) / 2);
+      const top = Math.round((containerHeight - renderedHeight) / 2);
+      return {
+        left,
+        top,
+        width: renderedWidth,
+        height: renderedHeight,
+      };
+    };
+    const syncSubtitleGeometry = () => {
+      const box = computeRenderedVideoBox();
+      const targets = [controller, assOverlayHost];
+      for (const target of targets) {
+        if (!target || !target.style) continue;
+        target.style.setProperty("--am-video-box-left", `${box.left}px`);
+        target.style.setProperty("--am-video-box-top", `${box.top}px`);
+        target.style.setProperty("--am-video-box-width", `${box.width}px`);
+        target.style.setProperty("--am-video-box-height", `${box.height}px`);
+      }
+      return box;
+    };
+    const refreshSubtitleLayers = () => {
+      const box = syncSubtitleGeometry();
+      const bridge = video.__amShakaTextBridge;
+      const ams = window.AmPlaybackSubtitles;
+      if (bridge && typeof bridge.setTextVisibility === "function") {
+        try {
+          bridge.setTextVisibility(bridge.isTextVisible ? bridge.isTextVisible() : true);
+        } catch (_) {
+          /* ignore */
+        }
+      }
+      if (
+        ams &&
+        typeof ams.refreshOctopusLayout === "function" &&
+        panel.__amLibassOctopus
+      ) {
+        try {
+          ams.refreshOctopusLayout(panel.__amLibassOctopus, {
+            video,
+            overlayRoot: assOverlayHost || undefined,
+            renderedBox: box,
+          });
+        } catch (_) {
+          /* ignore */
+        }
+      }
+    };
     const requestFullscreenOn = async (el) => {
       if (!el) throw new Error("No fullscreen target.");
       if (typeof el.requestFullscreen === "function") {
@@ -1020,20 +1424,28 @@
     };
     const toggleFullscreen = async () => {
       if (!fullscreenElement()) {
-        const targets = [controller, video];
-        let lastError = null;
-        for (const target of targets) {
-          try {
-            await requestFullscreenOn(target);
-            return;
-          } catch (err) {
-            lastError = err;
-          }
-        }
-        playerLog("error", "fullscreen_request_failed", {
-          message: lastError && lastError.message ? lastError.message : String(lastError || ""),
+        const target = resolveFullscreenTarget();
+        logFullscreenDiagnostics("before_enter_request", {
+          requested_target: describeElement(target),
+          ass_overlay_outside_target: !!(
+            assOverlayHost &&
+            target &&
+            typeof target.contains === "function" &&
+            !target.contains(assOverlayHost)
+          ),
         });
+        try {
+          await requestFullscreenOn(target);
+        } catch (err) {
+          const fallbackErr =
+            err && err.message ? err.message : String(err || "");
+          playerLog("error", "fullscreen_request_failed", {
+            message: fallbackErr,
+            requested_target: describeElement(target),
+          });
+        }
       } else {
+        logFullscreenDiagnostics("before_exit_request", {});
         try {
           await exitFullscreen();
         } catch (err) {
@@ -1043,14 +1455,20 @@
         }
       }
     };
-    if (fullscreenButton) {
-      fullscreenButton.addEventListener("click", (ev) => {
-        ev.preventDefault();
-        ev.stopPropagation();
-        toggleFullscreen().catch(() => {});
-      });
-    }
-
+    const onFullscreenChange = () => {
+      logFullscreenDiagnostics("fullscreenchange", {});
+      // SubtitlesOctopus can need a post-fullscreen geometry refresh.
+      refreshSubtitleLayers();
+      window.setTimeout(refreshSubtitleLayers, 140);
+    };
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    document.addEventListener("webkitfullscreenchange", onFullscreenChange);
+    video.addEventListener("loadedmetadata", refreshSubtitleLayers, { passive: true });
+    video.addEventListener("loadeddata", refreshSubtitleLayers, { passive: true });
+    video.addEventListener("resize", refreshSubtitleLayers, { passive: true });
+    window.addEventListener("resize", refreshSubtitleLayers, { passive: true });
+    logFullscreenDiagnostics("initialized", {});
+    refreshSubtitleLayers();
     host.setAttribute("tabindex", host.getAttribute("tabindex") || "0");
     host.addEventListener("keydown", (ev) => {
       const target = ev.target;
@@ -1075,6 +1493,9 @@
     });
 
     window.addEventListener("beforeunload", () => {
+      document.removeEventListener("fullscreenchange", onFullscreenChange);
+      document.removeEventListener("webkitfullscreenchange", onFullscreenChange);
+      window.removeEventListener("resize", refreshSubtitleLayers);
       savePosition();
       stopSession();
     });
@@ -1168,7 +1589,16 @@
         .closest("section")
         ?.querySelector?.("[data-stream-empty]");
 
+      const parsedLimit = parseInt(
+        String(tbody.getAttribute("data-stream-limit") || ""),
+        10,
+      );
+      const streamLimit = Number.isFinite(parsedLimit) && parsedLimit > 0
+        ? parsedLimit
+        : 200;
       let count = 0;
+      let seq = 0;
+      const heap = [];
       const url = tbody.getAttribute("data-stream-url");
       let source;
       try {
@@ -1183,13 +1613,77 @@
       }
       setSuffix();
 
-      function appendRow(html) {
-        // Use a <template> so the parser doesn't strip <tr> outside of
-        // a <table> context.
-        const tpl = document.createElement("template");
-        tpl.innerHTML = html.trim();
-        const row = tpl.content.firstElementChild;
-        if (!row) return;
+      function heapSwap(i, j) {
+        const tmp = heap[i];
+        heap[i] = heap[j];
+        heap[j] = tmp;
+      }
+
+      function heapSiftUp(index) {
+        let i = index;
+        while (i > 0) {
+          const parent = Math.floor((i - 1) / 2);
+          if (heap[parent].seeds <= heap[i].seeds) break;
+          heapSwap(parent, i);
+          i = parent;
+        }
+      }
+
+      function heapSiftDown(index) {
+        let i = index;
+        while (true) {
+          const left = i * 2 + 1;
+          const right = left + 1;
+          let smallest = i;
+          if (left < heap.length && heap[left].seeds < heap[smallest].seeds) {
+            smallest = left;
+          }
+          if (right < heap.length && heap[right].seeds < heap[smallest].seeds) {
+            smallest = right;
+          }
+          if (smallest === i) break;
+          heapSwap(i, smallest);
+          i = smallest;
+        }
+      }
+
+      function heapPush(entry) {
+        heap.push(entry);
+        heapSiftUp(heap.length - 1);
+      }
+
+      function heapReplaceMin(entry) {
+        if (heap.length === 0) {
+          heapPush(entry);
+          return null;
+        }
+        const removed = heap[0];
+        heap[0] = entry;
+        heapSiftDown(0);
+        return removed;
+      }
+
+      function orderedEntries() {
+        return heap.slice().sort((a, b) => {
+          if (a.seeds !== b.seeds) return b.seeds - a.seeds;
+          return a.seq - b.seq;
+        });
+      }
+
+      function syncTableFromHeap() {
+        const ordered = orderedEntries();
+        const frag = document.createDocumentFragment();
+        ordered.forEach((entry) => frag.appendChild(entry.row));
+        tbody.appendChild(frag);
+      }
+
+      function updateCount() {
+        count = heap.length;
+        if (counter) counter.textContent = String(count);
+        setSuffix();
+      }
+
+      function markRowForPager(row) {
         // Mount hidden so the pagination observer can decide whether
         // this row belongs on the current page before it paints —
         // prevents a flash of overflow rows during streaming.
@@ -1197,10 +1691,25 @@
           row.setAttribute("data-pager-hidden", "");
           row.style.display = "none";
         }
-        tbody.appendChild(row);
-        count += 1;
-        if (counter) counter.textContent = String(count);
-        setSuffix();
+      }
+
+      function parseStreamRow(html) {
+        // Use a <template> so the parser doesn't strip <tr> outside of
+        // a <table> context.
+        const tpl = document.createElement("template");
+        tpl.innerHTML = html.trim();
+        const row = tpl.content.firstElementChild;
+        if (!row) return null;
+        const seeds = parseInt(String(row.getAttribute("data-sort-seeds") || "0"), 10);
+        return {
+          row,
+          seeds: Number.isFinite(seeds) ? seeds : 0,
+          seq: ++seq,
+        };
+      }
+
+      function addKeptRow(row) {
+        markRowForPager(row);
         if (empty) empty.style.display = "none";
         // Signal the filter layer (if any) that a new row arrived so
         // it can extend its select options without rescanning the DOM
@@ -1211,6 +1720,28 @@
             detail: { row },
           }),
         );
+      }
+
+      function appendRow(html) {
+        const candidate = parseStreamRow(html);
+        if (!candidate) return;
+        if (heap.length < streamLimit) {
+          heapPush(candidate);
+          addKeptRow(candidate.row);
+          syncTableFromHeap();
+          updateCount();
+          return;
+        }
+        const minSeeds = heap[0] ? heap[0].seeds : -Infinity;
+        // Equal seeds keep earlier arrivals to avoid table churn.
+        if (candidate.seeds <= minSeeds) return;
+        const removed = heapReplaceMin(candidate);
+        if (removed && removed.row && removed.row.parentNode === tbody) {
+          removed.row.remove();
+        }
+        addKeptRow(candidate.row);
+        syncTableFromHeap();
+        updateCount();
       }
 
       source.addEventListener("row", (ev) => {
@@ -1433,7 +1964,7 @@
   // Client-side filtering for the torrent search results table.
   //
   // The filter bar (`[data-torrent-filters]`) exposes one <select> per
-  // facet (publisher, resolution, codec, season, episode kind). The
+  // facet (publisher, resolution, codec, season, episode, episode kind). The
   // current selections form an AND filter that is applied by hiding
   // non-matching <tr> elements via `data-filter-hidden`. Pagination
   // (`wireTablePagination`) ignores rows it has hidden itself but
@@ -1485,35 +2016,36 @@
       // Static facets (option list ships with the template).
       const STATIC_FACETS = new Set(["episode-kind"]);
 
-      // Range filters use a pair of <input type="number"> elements
-      // sharing `data-torrent-filter-range="<facet>"` and distinguished
-      // by `data-range-bound="min|max"`. Each facet maps to the
-      // `data-<facet>-start` / `data-<facet>-end` numeric attributes on
-      // a row. A row matches when its [start, end] overlaps the
-      // user-supplied [min, max] (either bound being NaN = unbounded).
-      const rangeInputs = Array.from(
-        bar.querySelectorAll("[data-torrent-filter-range]"),
-      );
-      const rangeFacets = new Set(
-        rangeInputs.map((el) => el.getAttribute("data-torrent-filter-range")),
-      );
-      const rangeAttrByFacet = {
-        episode: { start: "data-ep-start", end: "data-ep-end" },
-      };
+      // Episode numbers to offer in the dropdown (per row). Small
+      // ranges are expanded so middle episodes are selectable; wide
+      // ranges contribute endpoints only.
+      const EPISODE_ENUM_MAX = 96;
 
-      function rangeBounds(facet) {
-        let min = NaN;
-        let max = NaN;
-        rangeInputs.forEach((el) => {
-          if (el.getAttribute("data-torrent-filter-range") !== facet) return;
-          const v = el.value;
-          if (v === "" || v === null || v === undefined) return;
-          const n = Number(v);
-          if (Number.isNaN(n)) return;
-          if (el.getAttribute("data-range-bound") === "min") min = n;
-          else if (el.getAttribute("data-range-bound") === "max") max = n;
-        });
-        return { min, max };
+      function harvestEpisodeOptions(row, select) {
+        const startRaw = row.getAttribute("data-ep-start");
+        const endRaw = row.getAttribute("data-ep-end");
+        const start =
+          startRaw !== null && startRaw !== ""
+            ? Number(startRaw)
+            : NaN;
+        const end =
+          endRaw !== null && endRaw !== "" ? Number(endRaw) : NaN;
+        if (!Number.isNaN(start) && !Number.isNaN(end) && end >= start) {
+          const span = end - start;
+          if (span <= EPISODE_ENUM_MAX) {
+            for (let n = start; n <= end; n++) {
+              addOption(select, String(n), "Ep " + n);
+            }
+          } else {
+            addOption(select, String(start), "Ep " + start);
+            addOption(select, String(end), "Ep " + end);
+          }
+          return;
+        }
+        const single = row.getAttribute("data-episode") || "";
+        if (single) {
+          addOption(select, single, "Ep " + single);
+        }
       }
 
       // Pretty-print canonical publisher slugs for the dropdown.
@@ -1558,6 +2090,10 @@
         selects.forEach((sel) => {
           const facet = sel.getAttribute("data-torrent-filter");
           if (STATIC_FACETS.has(facet)) return;
+          if (facet === "episode") {
+            harvestEpisodeOptions(row, sel);
+            return;
+          }
           const attr = "data-" + facet;
           const value = row.getAttribute(attr) || "";
           if (!value) return;
@@ -1577,31 +2113,32 @@
           const want = sel.value;
           if (!want) continue;
           const facet = sel.getAttribute("data-torrent-filter");
+          if (facet === "episode") {
+            const n = Number(want);
+            if (Number.isNaN(n)) return false;
+            const startRaw = row.getAttribute("data-ep-start");
+            const endRaw = row.getAttribute("data-ep-end");
+            if (
+              startRaw !== null &&
+              startRaw !== "" &&
+              endRaw !== null &&
+              endRaw !== ""
+            ) {
+              const start = Number(startRaw);
+              const end = Number(endRaw);
+              if (Number.isNaN(start) || Number.isNaN(end) || n < start ||
+                  n > end) {
+                return false;
+              }
+            } else {
+              const have = row.getAttribute("data-episode") || "";
+              if (have === "" || Number(have) !== n) return false;
+            }
+            continue;
+          }
           const attr = "data-" + facet;
           const have = row.getAttribute(attr) || "";
           if (have !== want) return false;
-        }
-        for (const facet of rangeFacets) {
-          const { min, max } = rangeBounds(facet);
-          if (Number.isNaN(min) && Number.isNaN(max)) continue;
-          const meta = rangeAttrByFacet[facet];
-          if (!meta) continue;
-          const startRaw = row.getAttribute(meta.start);
-          const endRaw = row.getAttribute(meta.end);
-          if (startRaw === null || startRaw === "" ||
-              endRaw === null || endRaw === "") {
-            // Row has no numeric bounds for this facet -> exclude
-            // whenever the range filter is active.
-            return false;
-          }
-          const start = Number(startRaw);
-          const end = Number(endRaw);
-          if (Number.isNaN(start) || Number.isNaN(end)) return false;
-          // Interval overlap: [start, end] vs [min, max] (open bounds
-          // are treated as -Infinity / +Infinity).
-          const lo = Number.isNaN(min) ? -Infinity : min;
-          const hi = Number.isNaN(max) ? Infinity : max;
-          if (end < lo || start > hi) return false;
         }
         return true;
       }
@@ -1656,29 +2193,12 @@
       selects.forEach((sel) => {
         sel.addEventListener("change", apply);
       });
-      rangeInputs.forEach((el) => {
-        // Apply on each keystroke, but debounce slightly so we don't
-        // re-run filtering for every individual digit being typed.
-        let timer = null;
-        const queue = () => {
-          if (timer) window.clearTimeout(timer);
-          timer = window.setTimeout(() => {
-            timer = null;
-            apply();
-          }, 120);
-        };
-        el.addEventListener("input", queue);
-        el.addEventListener("change", apply);
-      });
 
       bar.querySelectorAll("[data-torrent-filter-reset]").forEach((btn) => {
         btn.addEventListener("click", (ev) => {
           ev.preventDefault();
           selects.forEach((sel) => {
             sel.value = "";
-          });
-          rangeInputs.forEach((el) => {
-            el.value = "";
           });
           apply();
         });
@@ -1720,6 +2240,8 @@
           label = publisherLabel(row, value);
         } else if (facet === "season") {
           label = "Season " + value;
+        } else if (facet === "episode") {
+          label = "Ep " + value;
         }
         if (!STATIC_FACETS.has(facet)) {
           addOption(sel, value, label);

--- a/clients/http/static/js/sw.js
+++ b/clients/http/static/js/sw.js
@@ -25,7 +25,7 @@
 // app.js had no ``wireLibrarySearchStream`` function, so without a
 // cache bump the page would stick on the server-rendered "Connecting…"
 // badge until the user manually reloaded twice.
-const CACHE_VERSION = "am-pwa-v3-search-focus";
+const CACHE_VERSION = "am-pwa-v9-libass-seek-resync";
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 
@@ -37,6 +37,7 @@ const PRECACHE_URLS = [
   "/ui/static/js/app.js",
   "/ui/static/js/pwa-register.js",
   "/ui/static/js/pwa-install.js",
+  "/ui/static/vendor/shaka-player/shaka-player.compiled.min.js",
   "/ui/static/icons/icon-192.png",
   "/ui/static/icons/icon-512.png",
   "/ui/static/icons/maskable-512.png",

--- a/clients/http/templates/anime_characters.html
+++ b/clients/http/templates/anime_characters.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% block title %}Characters — {{ anime.title }} — AnimeManager{% endblock %}
+
+{% block topbar_title %}Characters · {{ anime.title|truncate(40, true, '…') }}{% endblock %}
+
+{% block content %}
+  <nav class="watch-view__page-nav" aria-label="Characters page" style="margin-bottom: var(--sp-6)">
+    <a class="btn btn--ghost" href="{{ url_for('web_library') }}">← Library</a>
+    <a class="btn btn--ghost"
+       href="{{ url_for('web_anime_detail', anime_id=anime.id) }}">
+      ← Anime details
+    </a>
+  </nav>
+
+  <section class="detail__section">
+    <div class="detail__section-title">
+      <h3>Characters</h3>
+      <span class="meta">{{ characters|length }} in catalog</span>
+    </div>
+
+    {% if characters %}
+      <div class="grid">
+        {% for ch in characters %}
+          <div class="card" role="group" aria-label="{{ ch.name }}">
+            <div class="card__poster">
+              {% if ch.picture %}
+                <img
+                  src="{{ ch.picture }}"
+                  alt="{{ ch.name }}"
+                  loading="lazy"
+                  referrerpolicy="no-referrer"
+                />
+              {% else %}
+                <div class="card__poster-empty">
+                  {{ (ch.name or '?')|truncate(20, true, '…') }}
+                </div>
+              {% endif %}
+              {% if ch.role %}
+                <span class="card__status" title="{{ ch.role }}">{{ ch.role|capitalize }}</span>
+              {% endif %}
+            </div>
+            <span class="card__title">{{ ch.name }}</span>
+            {% if ch.synopsis %}
+              <p class="card__meta" style="white-space: normal; line-height: 1.35; max-height: 4.5em; overflow: hidden">
+                {{ ch.synopsis | striptags | truncate(180, true, '…') }}
+              </p>
+            {% else %}
+              <span class="card__meta"><span>No bio on file</span></span>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p style="color: var(--text-faint); font-size: 14px; max-width: 52ch">
+        No characters are stored for this title yet. They appear after metadata sync
+        populates the catalog (for example when character relations are saved from a provider).
+      </p>
+    {% endif %}
+  </section>
+{% endblock %}

--- a/clients/http/templates/anime_detail.html
+++ b/clients/http/templates/anime_detail.html
@@ -13,6 +13,12 @@
 {% endblock %}
 
 {% block content %}
+  <nav class="watch-view__page-nav" aria-label="Anime page" style="margin-bottom: var(--sp-5)">
+    <a class="btn btn--ghost"
+       href="{{ url_for('web_anime_characters', anime_id=anime.id) }}">
+      Characters
+    </a>
+  </nav>
   <section class="detail">
     <div class="detail__poster">
       {% if anime.picture %}
@@ -22,32 +28,91 @@
 
     <div>
       <div class="detail__head">
-        <span class="detail__eyebrow">{% if anime.status %}{{ anime.status|capitalize }}{% else %}Anime{% endif %} · ID {{ anime.id }}</span>
+        <span class="detail__eyebrow">
+          {% if computed_status_text %}{{ computed_status_text }}{% elif anime.status %}{{ anime.status|capitalize }}{% else %}Anime{% endif %}
+          · ID {{ anime.id }}
+        </span>
         <h1 class="detail__title">{{ anime.title }}</h1>
-        {% if anime.title_synonyms %}
-          <p class="detail__synonyms">{{ anime.title_synonyms | join(' · ') }}</p>
+        {% if alt_titles %}
+          <p class="detail__synonyms" title="Alternative titles">
+            {{ alt_titles | join(' · ') }}
+          </p>
         {% endif %}
 
         <div class="detail__stats">
           {% if anime.episodes %}<span class="badge">{{ anime.episodes }} episodes</span>{% endif %}
           {% if anime.duration %}<span class="badge">{{ anime.duration }} min · ep</span>{% endif %}
           {% if anime.rating %}<span class="badge">{{ anime.rating }}</span>{% endif %}
-          {% for g in (anime.genres or [])[:6] %}
-            <span class="badge">{{ g }}</span>
-          {% endfor %}
-          {% if user_state and user_state.get('tag') %}
+          {% if user_state and user_state.get('tag') and user_state.get('tag') != 'NONE' %}
             <span class="badge badge--accent">Tag · {{ user_state.tag }}</span>
           {% endif %}
           {% if user_state and user_state.get('liked') %}
             <span class="badge badge--good">Liked</span>
           {% endif %}
         </div>
+
+        {% if computed_status_text %}
+          <div class="detail__badges" aria-label="Airing status">
+            <span class="badge"{% if computed_status_color %} style="border-color: {{ computed_status_color }}; color: {{ computed_status_color }};"{% endif %}>
+              {{ computed_status_text }}
+            </span>
+          </div>
+        {% endif %}
       </div>
 
       {% if anime.synopsis %}
         <p class="detail__synopsis">{{ anime.synopsis }}</p>
       {% else %}
-        <p class="detail__synopsis" style="color: var(--text-faint)">No synopsis available.</p>
+        <p class="detail__synopsis detail__synopsis--empty">No synopsis available.</p>
+      {% endif %}
+
+      {% if detail_airing_fields or detail_metadata_fields or detail_genre_tags %}
+        <section class="detail__info" aria-label="Anime information">
+          <div class="detail__info-grid">
+            {% if detail_airing_fields %}
+              <article class="detail__info-card">
+                <h3 class="detail__info-label">Release &amp; Airing</h3>
+                <dl class="detail__kv">
+                  {% for field in detail_airing_fields %}
+                    <dt>{{ field.label }}</dt>
+                    <dd>
+                      {{ field.value }}
+                      {% if field.hint %}
+                        <span class="detail__kv-hint">{{ field.hint }}</span>
+                      {% endif %}
+                    </dd>
+                  {% endfor %}
+                </dl>
+              </article>
+            {% endif %}
+            {% if detail_metadata_fields %}
+              <article class="detail__info-card">
+                <h3 class="detail__info-label">More info</h3>
+                <dl class="detail__kv">
+                  {% for field in detail_metadata_fields %}
+                    <dt>{{ field.label }}</dt>
+                    <dd>
+                      {{ field.value }}
+                      {% if field.hint %}
+                        <span class="detail__kv-hint">{{ field.hint }}</span>
+                      {% endif %}
+                    </dd>
+                  {% endfor %}
+                </dl>
+              </article>
+            {% endif %}
+          </div>
+          {% if detail_genre_tags %}
+            <article class="detail__info-card detail__info-card--genres">
+              <h3 class="detail__info-label">Genres</h3>
+              <div class="detail__chips">
+                {% for tag in detail_genre_tags %}
+                  <span class="badge">{{ tag }}</span>
+                {% endfor %}
+              </div>
+            </article>
+          {% endif %}
+        </section>
       {% endif %}
 
       {% include "partials/anime_actions.html" %}
@@ -78,6 +143,20 @@
       </span>
     </form>
 
+    <form class="form-row"
+          method="post"
+          action="{{ url_for('web_action_start_download', anime_id=anime.id) }}"
+          style="margin-bottom: var(--sp-5)">
+      <input class="input"
+             type="text"
+             name="url"
+             placeholder="Paste magnet or .torrent URL"
+             autocomplete="off" />
+      <button class="btn" type="submit">Download from URL</button>
+    </form>
+
+    {% include "partials/search_terms.html" %}
+
     <div id="torrent-term-modal"
          class="modal"
          role="dialog"
@@ -100,9 +179,10 @@
                    id="anime-torrent-term"
                    form="anime-torrent-form"
                    name="term"
-                   placeholder="Optional: comma-separated term override (defaults to saved terms / title)"
+                   value="{{ last_torrent_search_query|default('', true)|e }}"
+                   placeholder="Optional: comma-separated override — blank uses last search, saved terms, or title"
                    autocomplete="off" />
-            <p class="meta">Leave blank to use saved terms (or the anime title when none are saved).</p>
+            <p class="meta">Leave blank to reuse your last search, then saved terms, then the anime title.</p>
           </div>
         </div>
       </div>
@@ -118,71 +198,20 @@
     </div>
   </section>
 
-  {% include "partials/anime_episode_player.html" %}
-
-  <section class="detail__section">
-    <div class="detail__section-title">
-      <h3>Downloaded episodes</h3>
-      <span class="meta">
-        {% if anime_torrents %}{{ anime_torrents|length }} torrent{{ '' if anime_torrents|length == 1 else 's' }}{% else %}Nothing downloaded yet{% endif %}
-      </span>
-    </div>
-
-    {% if anime_torrents %}
-      <div class="table-wrap">
-      <table class="table table--anime-downloads">
-        <colgroup>
-          <col class="col--release" />
-          <col class="col--size" />
-          <col class="col--progress" />
-          <col class="col--state" />
-        </colgroup>
-        <thead>
-          <tr>
-            <th class="truncate">Release</th>
-            <th class="num">Size</th>
-            <th class="num">Progress</th>
-            <th>State</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in anime_torrents %}
-            {% set pct = ((row.progress or 0) * 100)|round(1) if row.progress is not none else None %}
-            <tr>
-              <td class="truncate" title="{{ row.name }}">
-                {{ row.name or row.hash or '—' }}
-                {% if row.path %}<div style="font-size:11px; color: var(--text-faint)">{{ row.path }}</div>{% endif %}
-              </td>
-              <td class="num">{{ row.size_human or '—' }}</td>
-              <td class="num" style="min-width: 120px">
-                {% if pct is not none %}
-                  <div class="progress" aria-label="Download progress">
-                    <div class="progress__bar" style="width: {{ pct }}%"></div>
-                  </div>
-                  <span style="font-size: 11px; color: var(--text-muted)">{{ pct }}%</span>
-                {% else %}—{% endif %}
-              </td>
-              <td>
-                {% set state = (row.state or 'SAVED')|upper %}
-                {% if state == 'COMPLETE' %}
-                  <span class="badge badge--good">{{ state }}</span>
-                {% elif state == 'DOWNLOADING' %}
-                  <span class="badge badge--accent">{{ state }}</span>
-                {% else %}
-                  <span class="badge">{{ state }}</span>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+  <div id="anime-episodes-panel-mount"
+       hx-get="{{ url_for('web_anime_episodes_panel', anime_id=anime.id) }}"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+    <section class="detail__section" aria-busy="true">
+      <div class="detail__section-title">
+        <h3>Episodes &amp; downloads</h3>
+        <span class="meta">Loading…</span>
       </div>
-    {% else %}
-      <p style="color: var(--text-faint); font-size: 13px">
-        Nothing downloaded yet — pick a release from the torrent search above to start.
+      <p style="color: var(--text-faint); font-size: 13px" class="htmx-indicator">
+        Scanning local media and torrent state…
       </p>
-    {% endif %}
-  </section>
+    </section>
+  </div>
 
   {% if relations %}
     <section class="detail__section">
@@ -203,7 +232,12 @@
           {% for rel in relations %}
             <tr>
               <td>{{ rel.title or rel.name or '—' }}</td>
-              <td><span class="badge">{{ rel.type or 'related' }}</span></td>
+              <td>
+                <span class="badge">{{ rel.type or 'related' }}</span>
+                {% if rel.rel_tag and rel.rel_tag != 'NONE' %}
+                  <span class="badge badge--accent">Tag · {{ rel.rel_tag }}</span>
+                {% endif %}
+              </td>
               <td class="num">
                 {% if rel.id %}
                   <a class="btn btn--ghost" href="{{ url_for('web_anime_detail', anime_id=rel.id) }}">Open</a>

--- a/clients/http/templates/partials/anime_actions.html
+++ b/clients/http/templates/partials/anime_actions.html
@@ -70,4 +70,31 @@
       </a>
     {% endif %}
   {% endif %}
+
+  <details style="width: 100%; margin-top: var(--sp-3);">
+    <summary class="meta" style="cursor: pointer;">Danger zone</summary>
+    <div style="display: flex; flex-wrap: wrap; gap: var(--sp-2); margin-top: var(--sp-2);">
+      <form method="post" action="{{ url_for('web_action_redownload', anime_id=anime.id) }}" style="display:inline">
+        <button class="btn" type="submit">Redownload</button>
+      </form>
+      <form method="post"
+            action="{{ url_for('web_action_delete_seen_episodes', anime_id=anime.id) }}"
+            onsubmit="return confirm('Delete seen episodes from disk?');"
+            style="display:inline">
+        <button class="btn btn--danger" type="submit">Delete seen episodes</button>
+      </form>
+      <form method="post"
+            action="{{ url_for('web_action_delete_all_files', anime_id=anime.id) }}"
+            onsubmit="return confirm('Delete all local files for this anime?');"
+            style="display:inline">
+        <button class="btn btn--danger" type="submit">Delete all files</button>
+      </form>
+      <form method="post"
+            action="{{ url_for('web_action_remove_anime', anime_id=anime.id) }}"
+            onsubmit="return confirm('Remove this anime from database?');"
+            style="display:inline">
+        <button class="btn btn--danger" type="submit">Remove from DB</button>
+      </form>
+    </div>
+  </details>
 </div>

--- a/clients/http/templates/partials/anime_torrent_results.html
+++ b/clients/http/templates/partials/anime_torrent_results.html
@@ -5,7 +5,13 @@
 {% if term %}
   <p class="anime-torrent-summary"
      style="color: var(--text-faint); font-size: 12px; margin-bottom: var(--sp-3)">
-    {% if fallback_used %}Using saved search terms / title:{% else %}Search:{% endif %}
+    {% if torrent_term_source in ('saved', 'title') %}
+      Using saved search terms / title:
+    {% elif torrent_term_source == 'memory' %}
+      Using last search:
+    {% else %}
+      Search:
+    {% endif %}
     <strong style="color: var(--text-muted)">{{ term }}</strong>
     ·
     <span data-stream-count>0</span>
@@ -58,6 +64,7 @@
         </tr>
       </thead>
       <tbody data-stream-rows data-paginate
+             data-stream-limit="{{ stream_limit or 200 }}"
              data-stream-url="{{ url_for('web_anime_torrent_stream', anime_id=anime_id) }}?term={{ term|urlencode }}">
       </tbody>
     </table>

--- a/clients/http/templates/partials/anime_torrent_row.html
+++ b/clients/http/templates/partials/anime_torrent_row.html
@@ -166,10 +166,13 @@
       {% if anime_id %}
         <form method="post"
               action="{{ url_for('web_action_start_download', anime_id=anime_id) }}"
+              data-torrent-download-form
               style="display:inline">
           <input type="hidden" name="url" value="{{ row.link }}" />
           {% if row.hash %}<input type="hidden" name="hash_value" value="{{ row.hash }}" />{% endif %}
-          <button class="btn btn--primary btn--small" type="submit">Download</button>
+          <button class="btn btn--primary btn--small"
+                  type="submit"
+                  data-torrent-download-button>Download</button>
         </form>
       {% else %}
         <a class="btn btn--small" href="{{ row.link }}" target="_blank" rel="noreferrer">Open</a>

--- a/clients/http/templates/partials/torrent_filters_bar.html
+++ b/clients/http/templates/partials/torrent_filters_bar.html
@@ -46,29 +46,15 @@
       <option value="">All seasons</option>
     </select>
   </label>
-  {# Episode range filter -- two compact <input type="number"> boxes.
-     A row matches when its [data-ep-start, data-ep-end] interval
-     overlaps the [min, max] selection. Either bound is optional.
-     Setting min=max behaves like an "episode equals" filter; batches
-     match any range because their bounds are [1, 99999]. #}
-  <div class="torrent-filters__field torrent-filters__field--range"
-       data-torrent-filter-range-group="episode"
-       role="group" aria-label="Filter by episode number">
+  {# Episode dropdown: options are derived from rows (see wireTorrentFilters).
+     Selecting N keeps any release whose [data-ep-start, data-ep-end]
+     contains N; rows with no bounds fall back to data-episode. #}
+  <label class="torrent-filters__field">
     <span class="torrent-filters__label">Episode</span>
-    <div class="torrent-filters__range">
-      <input type="number" min="0" inputmode="numeric"
-             class="torrent-filters__input"
-             data-torrent-filter-range="episode"
-             data-range-bound="min"
-             placeholder="Min" aria-label="Minimum episode" />
-      <span class="torrent-filters__range-sep" aria-hidden="true">–</span>
-      <input type="number" min="0" inputmode="numeric"
-             class="torrent-filters__input"
-             data-torrent-filter-range="episode"
-             data-range-bound="max"
-             placeholder="Max" aria-label="Maximum episode" />
-    </div>
-  </div>
+    <select data-torrent-filter="episode" class="torrent-filters__select" aria-label="Filter by episode number">
+      <option value="">All episodes</option>
+    </select>
+  </label>
   <label class="torrent-filters__field">
     <span class="torrent-filters__label">Type</span>
     <select data-torrent-filter="episode-kind" class="torrent-filters__select" aria-label="Filter by release type">

--- a/clients/http/web.py
+++ b/clients/http/web.py
@@ -14,13 +14,17 @@ plain HTML form so the app works without JavaScript.
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import json
 import ipaddress
 import logging
+import os
 import queue
 import re
 import threading
-from pathlib import Path
+import time
+import types
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 from urllib.parse import parse_qs, urlparse
 
@@ -45,6 +49,8 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 try:  # pragma: no cover - import path differs depending on launch mode
+    from ...shared.config.getters import Getters
+    from ...domain.entities import title_variants_for_torrent_search
     from ...domain.errors import (
         AnimeManagerError,
         NotFoundError,
@@ -54,8 +60,10 @@ try:  # pragma: no cover - import path differs depending on launch mode
     from ..sdk import ClientSDK
     from . import log_buffer, settings_form
 except ImportError:  # pragma: no cover
+    from shared.config.getters import Getters  # type: ignore  # noqa: F401
     from clients.sdk import ClientSDK
     from clients.http import log_buffer, settings_form  # type: ignore  # noqa: F401
+    from domain.entities import title_variants_for_torrent_search  # type: ignore  # noqa: F401
     from domain.errors import (  # type: ignore  # noqa: F401
         AnimeManagerError,
         NotFoundError,
@@ -64,6 +72,24 @@ except ImportError:  # pragma: no cover
     )
 
 _LOG = logging.getLogger(__name__)
+
+# Per-anime metadata refresh throttle (max once per hour).
+_METADATA_REFRESH_TS: dict[int, float] = {}
+_METADATA_REFRESH_INTERVAL_S = 3600.0
+
+
+def _maybe_refresh_anime_metadata(sdk: ClientSDK, anime_id: int) -> None:
+    """Best-effort metadata refresh when opening anime detail (rate limited)."""
+    now = time.monotonic()
+    last = _METADATA_REFRESH_TS.get(int(anime_id))
+    if last is not None and (now - last) < _METADATA_REFRESH_INTERVAL_S:
+        return
+    _METADATA_REFRESH_TS[int(anime_id)] = now
+    try:
+        getattr(sdk, "refresh_anime_metadata", lambda _id: None)(anime_id)
+    except Exception as exc:  # noqa: BLE001
+        _LOG.warning("auto refresh_anime_metadata failed: %s", exc)
+
 
 # ---------------------------------------------------------------------------
 # Resource paths
@@ -156,6 +182,414 @@ def _safe_int(value: Any, default: int) -> int:
         return default
 
 
+def _format_unix_date(value: Any) -> str | None:
+    """Best-effort ``YYYY-MM-DD`` formatter for Unix timestamps."""
+    try:
+        stamp = int(float(value))
+    except (TypeError, ValueError):
+        return None
+    if stamp <= 0:
+        return None
+    try:
+        return dt.datetime.fromtimestamp(
+            stamp, tz=dt.timezone.utc
+        ).strftime("%Y-%m-%d")
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        source = value
+    else:
+        source = [value]
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in source:
+        text = str(raw or "").strip()
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(text)
+    return out
+
+
+_UNKNOWN_GENRE = "Unknown genre"
+
+
+def _detail_field(label: str, value: Any, *, hint: str | None = None) -> dict[str, str] | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    row: dict[str, str] = {"label": label, "value": text}
+    hint_text = str(hint or "").strip()
+    if hint_text:
+        row["hint"] = hint_text
+    return row
+
+
+def _split_value_hint(text: str) -> tuple[str, str | None]:
+    """Split ``Since 07 Apr 2026 (41 days)`` into value + parenthetical hint."""
+    cleaned = str(text or "").strip()
+    match = re.match(r"^(.*?)(?:\s*\(([^)]+)\))?\s*$", cleaned)
+    if not match:
+        return cleaned, None
+    value = str(match.group(1) or "").strip()
+    hint = str(match.group(2) or "").strip() or None
+    return value, hint
+
+
+def _parse_schedule_line(line: str) -> dict[str, str]:
+    """Map legacy schedule strings to user-facing labels."""
+    text = str(line or "").strip()
+    lower = text.casefold()
+    if lower.startswith("since "):
+        value, hint = _split_value_hint(text[6:])
+        return _detail_field("Airs", value, hint=hint) or {"label": "Airs", "value": text}
+    if lower.startswith("from "):
+        value, hint = _split_value_hint(text[5:])
+        return _detail_field("Started", value, hint=hint) or {"label": "Started", "value": text}
+    if lower.startswith("to "):
+        value, hint = _split_value_hint(text[3:])
+        return _detail_field("Ended", value, hint=hint) or {"label": "Ended", "value": text}
+    if lower.startswith("next episode"):
+        if lower.startswith("next episode on "):
+            value = text[16:].strip()
+        elif lower.startswith("next episode: "):
+            value = text[14:].strip()
+        else:
+            value = text[14:].strip()
+        return _detail_field("Next episode", value) or {"label": "Next episode", "value": text}
+    if lower.startswith("latest episode"):
+        value = text.split(":", 1)[-1].strip() if ":" in text else text[15:].strip()
+        return _detail_field("Latest episode", value) or {"label": "Latest episode", "value": text}
+    if "days left" in lower:
+        value, hint = _split_value_hint(text)
+        return _detail_field("Premieres", value, hint=hint) or {"label": "Premieres", "value": text}
+    return {"label": "Timeline", "value": text}
+
+
+def _lookup_genre_index_names(index_ids: list[str]) -> dict[str, str]:
+    """Resolve ``genresIndex`` ids to display names."""
+    numeric: list[int] = []
+    for raw in index_ids:
+        try:
+            numeric.append(int(str(raw).strip()))
+        except (TypeError, ValueError):
+            continue
+    if not numeric:
+        return {}
+    try:
+        db = Getters.getDatabase(None)
+        placeholders = ",".join("?" for _ in numeric)
+        sql = f"SELECT id, value FROM genresIndex WHERE id IN ({placeholders})"
+        rows = db.sql(sql, tuple(numeric))
+    except Exception:  # noqa: BLE001
+        return {}
+    out: dict[str, str] = {}
+    for row in rows or []:
+        if not row or len(row) < 2:
+            continue
+        key = str(row[0]).strip()
+        name = str(row[1] or "").strip()
+        if key and name:
+            out[key] = name
+    return out
+
+
+def _resolve_genre_tags(anime_id: int | None, raw_genres: Any) -> list[str]:
+    """Return human-readable genre names, never raw index ids."""
+    if anime_id is not None:
+        try:
+            db = Getters.getDatabase(None)
+            fetcher = getattr(db, "_fetch_genre_metadata_for_id", None)
+            if callable(fetcher):
+                resolved = _string_list(fetcher(anime_id))
+                if resolved:
+                    return resolved
+        except Exception:  # noqa: BLE001
+            pass
+
+    raw_values = _string_list(raw_genres)
+    if not raw_values:
+        return []
+
+    numeric_ids = [value for value in raw_values if value.isdigit()]
+    index_names = _lookup_genre_index_names(numeric_ids)
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in raw_values:
+        if value.isdigit():
+            name = index_names.get(value)
+            label = name or _UNKNOWN_GENRE
+        else:
+            label = value
+        key = label.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(label)
+    return out
+
+
+def _build_anime_detail_view(
+    anime: dict[str, Any],
+    *,
+    anime_id: int | None,
+    terms: list[str],
+    computed_status_text: str,
+    schedule_lines: list[str],
+) -> dict[str, Any]:
+    """Grouped, display-safe fields for the anime detail template."""
+    title = str(anime.get("title") or "").strip()
+    alt_titles = [
+        value
+        for value in _string_list(anime.get("title_synonyms"))
+        if value.casefold() != title.casefold()
+    ]
+    genre_tags = _resolve_genre_tags(anime_id, anime.get("genres"))
+
+    airing_fields: list[dict[str, str]] = []
+    status_field = _detail_field("Status", computed_status_text)
+    if status_field:
+        airing_fields.append(status_field)
+    for line in schedule_lines:
+        airing_fields.append(_parse_schedule_line(line))
+
+    metadata_fields: list[dict[str, str]] = []
+    for label, value in (
+        ("Start date", _format_unix_date(anime.get("date_from"))),
+        ("End date", _format_unix_date(anime.get("date_to"))),
+        ("Broadcast", anime.get("broadcast")),
+        ("Last seen", anime.get("last_seen")),
+    ):
+        field = _detail_field(label, value)
+        if field:
+            metadata_fields.append(field)
+    if terms:
+        field = _detail_field("Saved search terms", ", ".join(_string_list(terms)))
+        if field:
+            metadata_fields.append(field)
+
+    return {
+        "alt_titles": alt_titles,
+        "genre_tags": genre_tags,
+        "airing_fields": airing_fields,
+        "metadata_fields": metadata_fields,
+    }
+
+
+def anime_detail_display_for_api(
+    sdk: ClientSDK,
+    anime_id: int,
+    *,
+    anime: dict[str, Any] | None = None,
+    terms: list[str] | None = None,
+) -> dict[str, Any]:
+    """JSON display extras for :func:`clients.http.app.ui_api_anime_bundle`."""
+    resolved = anime if isinstance(anime, dict) else sdk.get_anime(anime_id) or {}
+    terms_list = list(terms if terms is not None else sdk.get_search_terms(anime_id) or [])
+    settings: dict[str, Any] = {}
+    try:
+        settings = sdk.get_settings() or {}
+    except Exception:  # noqa: BLE001
+        settings = {}
+
+    trailer_embed: str | None = None
+    computed_status = "UNKNOWN"
+    computed_status_text = "Unknown"
+    computed_status_color = ""
+    schedule_lines: list[str] = []
+    alt_titles: list[str] = []
+    detail_genre_tags: list[str] = []
+    detail_airing_fields: list[dict[str, str]] = []
+    detail_metadata_fields: list[dict[str, str]] = []
+
+    if isinstance(resolved, dict):
+        trailer_embed = _youtube_embed_url(resolved.get("trailer"))
+        computed_status, schedule_lines = _legacy_status_lines(resolved)
+        computed_status_text, computed_status_color = _status_theme_meta(
+            settings, computed_status
+        )
+        detail_view = _build_anime_detail_view(
+            resolved,
+            anime_id=anime_id,
+            terms=terms_list,
+            computed_status_text=computed_status_text,
+            schedule_lines=schedule_lines,
+        )
+        alt_titles = detail_view["alt_titles"]
+        detail_genre_tags = detail_view["genre_tags"]
+        detail_airing_fields = detail_view["airing_fields"]
+        detail_metadata_fields = detail_view["metadata_fields"]
+
+    relations: list[dict[str, Any]] = []
+    try:
+        relations = _enrich_relations_with_user_tag(
+            sdk, list(sdk.get_relations(anime_id) or [])
+        )
+    except Exception:  # noqa: BLE001
+        relations = []
+
+    return {
+        "trailer_embed": trailer_embed,
+        "alt_titles": alt_titles,
+        "detail_genre_tags": detail_genre_tags,
+        "detail_airing_fields": detail_airing_fields,
+        "detail_metadata_fields": detail_metadata_fields,
+        "computed_status": computed_status,
+        "computed_status_text": computed_status_text,
+        "computed_status_color": computed_status_color,
+        "relations": relations,
+    }
+
+
+def watch_context_for_api(
+    sdk: ClientSDK,
+    anime_id: int,
+    *,
+    file_id: str = "",
+    user_id: int = DEFAULT_USER_ID,
+) -> dict[str, Any]:
+    """Watch-page player context for Next.js (mirrors ``web_anime_watch``)."""
+    anime = sdk.get_anime(anime_id)
+    try:
+        episode_files = list(sdk.list_episode_files(anime_id, user_id=user_id) or [])
+    except Exception:  # noqa: BLE001
+        episode_files = []
+
+    selected_file_id = str(file_id or "").strip()
+    if not selected_file_id and episode_files:
+        selected_file_id = str(episode_files[0].get("file_id") or "")
+    selected_title = ""
+    selected_audio_tracks: list[dict[str, Any]] = []
+    selected_subtitle_tracks: list[dict[str, Any]] = []
+    for item in episode_files:
+        if str(item.get("file_id") or "") == selected_file_id:
+            selected_title = str(item.get("title") or "")
+            selected_audio_tracks = list(item.get("audio_tracks") or [])
+            selected_subtitle_tracks = list(item.get("subtitle_tracks") or [])
+            break
+
+    track_map: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    episode_resume_map: dict[str, float] = {}
+    for item in episode_files:
+        fid = str(item.get("file_id") or "")
+        if not fid:
+            continue
+        track_map[fid] = {
+            "audio": list(item.get("audio_tracks") or []),
+            "subtitles": list(item.get("subtitle_tracks") or []),
+        }
+        pos_raw = item.get("position_seconds")
+        try:
+            pos = float(pos_raw) if pos_raw is not None else 0.0
+        except (TypeError, ValueError):
+            pos = 0.0
+        if pos >= 10.0:
+            episode_resume_map[fid] = pos
+
+    return {
+        "anime": anime,
+        "episode_files": episode_files,
+        "selected_file_id": selected_file_id,
+        "selected_file_title": selected_title,
+        "selected_audio_tracks": selected_audio_tracks,
+        "selected_subtitle_tracks": selected_subtitle_tracks,
+        "track_map": track_map,
+        "episode_resume_map": episode_resume_map,
+        "play_endpoint": f"/ui/anime/{anime_id}/play",
+        "progress_endpoint": f"/ui/anime/{anime_id}/episode-progress",
+    }
+
+
+def _anime_info_rows(
+    anime: dict[str, Any],
+    *,
+    user_state: dict[str, Any],
+    terms: list[str],
+) -> tuple[list[str], list[str], list[tuple[str, str]]]:
+    """Legacy tuple API; prefer :func:`_build_anime_detail_view`."""
+    anime_id_raw = anime.get("id")
+    anime_id: int | None
+    try:
+        anime_id = int(anime_id_raw) if anime_id_raw is not None else None
+    except (TypeError, ValueError):
+        anime_id = None
+    view = _build_anime_detail_view(
+        anime,
+        anime_id=anime_id,
+        terms=terms,
+        computed_status_text="",
+        schedule_lines=[],
+    )
+    rows = [
+        (field["label"], field["value"])
+        for field in view["metadata_fields"]
+    ]
+    return view["genre_tags"], view["alt_titles"], rows
+
+
+def _legacy_status_lines(anime: dict[str, Any]) -> tuple[str, list[str]]:
+    """Reuse legacy status/date text policy from ``shared.config.getters``."""
+    obj = types.SimpleNamespace(
+        status=anime.get("status"),
+        date_from=anime.get("date_from"),
+        date_to=anime.get("date_to"),
+        episodes=anime.get("episodes"),
+        broadcast=anime.get("broadcast"),
+    )
+    status = str(Getters.getStatus(obj) or "UNKNOWN").upper()
+
+    class _LegacyShim:
+        @staticmethod
+        def getStatus(anime_obj):
+            return Getters.getStatus(anime_obj)
+
+    try:
+        lines = list(Getters.getDateText(_LegacyShim(), obj) or [])
+    except Exception:  # noqa: BLE001
+        lines = []
+    return status, [str(line).strip() for line in lines if str(line).strip()]
+
+
+def _status_theme_meta(
+    settings: dict[str, Any], status: str
+) -> tuple[str, str]:
+    ui = settings.get("UI", {}) if isinstance(settings, dict) else {}
+    date_states = ui.get("dateStates", {}) if isinstance(ui, dict) else {}
+    state_meta = date_states.get(status, {}) if isinstance(date_states, dict) else {}
+    text = str(state_meta.get("text") or status.title()).strip()
+    color_key = str(state_meta.get("color") or "White").strip()
+    colors = ui.get("colors", {}) if isinstance(ui, dict) else {}
+    color = str(colors.get(color_key) or "").strip()
+    return text, color
+
+
+def _enrich_relations_with_user_tag(
+    sdk: ClientSDK, relations: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for rel in relations:
+        row = dict(rel or {})
+        rel_id = row.get("id")
+        rel_tag = "NONE"
+        try:
+            if rel_id is not None:
+                state = sdk.get_user_state(int(rel_id), DEFAULT_USER_ID) or {}
+                rel_tag = str(state.get("tag") or "NONE").upper()
+        except Exception:  # noqa: BLE001
+            rel_tag = "NONE"
+        row["rel_tag"] = rel_tag
+        out.append(row)
+    return out
+
+
 _YOUTUBE_HOSTS = {
     "youtube.com",
     "www.youtube.com",
@@ -220,9 +654,9 @@ def _humanize_size(num: Any) -> str | None:
 def _collect_anime_torrents(sdk: ClientSDK, anime_id: int) -> list[dict[str, Any]]:
     """Return the union of saved + in-flight torrents for ``anime_id``.
 
-    The detail page surfaces both the "Downloaded episodes" library
-    (persisted torrent metadata) and any task currently making progress
-    for the same anime, so the user always sees a single accurate list.
+    The anime detail "Episodes & downloads" section shows persisted
+    torrent metadata together with any in-memory task for the same
+    anime so the list stays accurate.
     Missing SDK methods or backend errors degrade to an empty list --
     every other section on the page is independent.
     """
@@ -394,6 +828,32 @@ def _redirect_get(path: str) -> RedirectResponse:
     return RedirectResponse(path, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
 
 
+def _post_download_redirect_path(request: Request, anime_id: int) -> str:
+    """Pick a safe 303 target after download start/cancel so users stay on the page they used.
+
+    When the browser sends a same-origin ``Referer`` under ``/ui/``, return
+    that path (and query); otherwise fall back to the anime detail URL.
+    """
+    fallback = f"/ui/anime/{anime_id}"
+    raw = (request.headers.get("referer") or "").strip()
+    if not raw:
+        return fallback
+    try:
+        ref = urlparse(raw)
+    except ValueError:
+        return fallback
+    if ref.scheme not in ("http", "https"):
+        return fallback
+    if (ref.netloc or "").lower() != request.url.netloc.lower():
+        return fallback
+    path = ref.path or ""
+    if not path.startswith("/ui/") or ".." in PurePosixPath(path).parts:
+        return fallback
+    if ref.query:
+        return f"{path}?{ref.query}"
+    return path
+
+
 def _is_htmx(request: Request) -> bool:
     """Return True when the request was issued by HTMX.
 
@@ -431,15 +891,15 @@ def _anime_actions_response(
     return _render(
         request,
         "partials/anime_actions.html",
-        {"anime": anime, "user_state": user_state},
+        {
+            "anime": anime,
+            "user_state": user_state,
+        },
     )
 
 
-def _episode_player_response(request: Request, anime_id: int) -> Response:
-    """Swap the episode table after HTMX mutations; redirect otherwise."""
-    if not _is_htmx(request):
-        return _redirect(f"/ui/anime/{anime_id}")
-    sdk = get_sdk()
+def _anime_episodes_panel_context(sdk: ClientSDK, anime_id: int) -> dict[str, Any]:
+    """Build template context for the merged episode + torrent tables."""
     try:
         anime = sdk.get_anime(anime_id)
     except Exception:  # noqa: BLE001
@@ -451,10 +911,27 @@ def _episode_player_response(request: Request, anime_id: int) -> Response:
     except Exception:  # noqa: BLE001
         _LOG.debug("episode file lookup failed (panel)", exc_info=True)
         episode_files = []
+    anime_torrents = _collect_anime_torrents(sdk, anime_id)
+    return {
+        "anime": anime,
+        "episode_files": episode_files,
+        "anime_torrents": anime_torrents,
+    }
+
+
+def _episode_player_response(request: Request, anime_id: int) -> Response:
+    """Swap the episode table after HTMX mutations; silent 204 for in-player
+    ``fetch`` (avoids 303 + full-page GET during streaming); redirect otherwise.
+    """
+    if request.headers.get("x-am-player-background", "").lower() == "true":
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    if not _is_htmx(request):
+        return _redirect(f"/ui/anime/{anime_id}")
+    sdk = get_sdk()
     return _render(
         request,
         "partials/anime_episode_player.html",
-        {"anime": anime, "episode_files": episode_files},
+        _anime_episodes_panel_context(sdk, anime_id),
     )
 
 
@@ -526,13 +1003,36 @@ def _is_client_allowed_for_streaming(request: Request, sdk: ClientSDK) -> bool:
     return bool(ip.is_private or ip.is_loopback or ip.is_link_local)
 
 
+def _next_ui_base_url() -> str:
+    """Return configured Next.js UI origin or empty string when disabled."""
+    return str(os.getenv("ANIMEMANAGER_NEXT_UI_URL", "")).strip().rstrip("/")
+
+
+def _next_ui_redirect_for_request(request: Request) -> RedirectResponse | None:
+    """Redirect `/ui/*` page requests to Next.js when cutover is enabled."""
+    base = _next_ui_base_url()
+    if not base:
+        return None
+    path = request.url.path or "/ui/library"
+    if path.startswith("/ui"):
+        path = path[3:] or "/"
+    query = str(request.url.query or "").strip()
+    target = f"{base}{path}"
+    if query:
+        target = f"{target}?{query}"
+    return RedirectResponse(target, status_code=307)
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
 
 
 @router.get("/ui", include_in_schema=False)
-def web_ui_root() -> RedirectResponse:
+def web_ui_root(request: Request) -> RedirectResponse:
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     return _redirect_get("/ui/library")
 
 
@@ -543,6 +1043,9 @@ def web_library(
     q: str | None = None,
     page: int = 1,
 ) -> HTMLResponse:
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     sdk = get_sdk()
     page = max(1, _safe_int(page, 1))
     list_start = (page - 1) * PAGE_SIZE
@@ -801,6 +1304,9 @@ async def web_library_search_ws(websocket: WebSocket) -> None:
 
 @router.get("/ui/anime/{anime_id}", name="web_anime_detail")
 def web_anime_detail(request: Request, anime_id: int) -> HTMLResponse:
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     sdk = get_sdk()
     try:
         anime = sdk.get_anime(anime_id)
@@ -817,6 +1323,12 @@ def web_anime_detail(request: Request, anime_id: int) -> HTMLResponse:
             status_code=404,
         )
 
+    _maybe_refresh_anime_metadata(sdk, anime_id)
+    try:
+        anime = sdk.get_anime(anime_id)
+    except Exception:  # noqa: BLE001
+        pass
+
     user_state: dict[str, Any] = {}
     terms: list[str] = []
     relations: list[dict[str, Any]] = []
@@ -828,23 +1340,49 @@ def web_anime_detail(request: Request, anime_id: int) -> HTMLResponse:
         terms = list(sdk.get_search_terms(anime_id) or [])
     except Exception:  # noqa: BLE001
         _LOG.debug("search_terms lookup failed", exc_info=True)
+    last_torrent_search_query: str | None = None
+    try:
+        last_torrent_search_query = sdk.get_last_torrent_search_query(anime_id)
+    except Exception:  # noqa: BLE001
+        _LOG.debug("last_torrent_search_query lookup failed", exc_info=True)
     try:
         relations = list(sdk.get_relations(anime_id) or [])
     except Exception:  # noqa: BLE001
         _LOG.debug("relations lookup failed", exc_info=True)
+    relations = _enrich_relations_with_user_tag(sdk, relations)
+
+    settings: dict[str, Any] = {}
+    try:
+        settings = sdk.get_settings() or {}
+    except Exception:  # noqa: BLE001
+        settings = {}
 
     trailer_embed: str | None = None
+    alt_titles: list[str] = []
+    detail_genre_tags: list[str] = []
+    detail_airing_fields: list[dict[str, str]] = []
+    detail_metadata_fields: list[dict[str, str]] = []
+    computed_status = "UNKNOWN"
+    computed_status_text = "Unknown"
+    computed_status_color = ""
+    schedule_lines: list[str] = []
     if isinstance(anime, dict):
         trailer_embed = _youtube_embed_url(anime.get("trailer"))
-
-    anime_torrents = _collect_anime_torrents(sdk, anime_id)
-    try:
-        episode_files = list(
-            sdk.list_episode_files(anime_id, user_id=DEFAULT_USER_ID) or []
+        computed_status, schedule_lines = _legacy_status_lines(anime)
+        computed_status_text, computed_status_color = _status_theme_meta(
+            settings, computed_status
         )
-    except Exception:  # noqa: BLE001
-        _LOG.debug("episode file lookup failed", exc_info=True)
-        episode_files = []
+        detail_view = _build_anime_detail_view(
+            anime,
+            anime_id=anime_id,
+            terms=terms,
+            computed_status_text=computed_status_text,
+            schedule_lines=schedule_lines,
+        )
+        alt_titles = detail_view["alt_titles"]
+        detail_genre_tags = detail_view["genre_tags"]
+        detail_airing_fields = detail_view["airing_fields"]
+        detail_metadata_fields = detail_view["metadata_fields"]
 
     return _render(
         request,
@@ -853,13 +1391,83 @@ def web_anime_detail(request: Request, anime_id: int) -> HTMLResponse:
             "anime": anime,
             "user_state": user_state,
             "terms": terms,
+            "last_torrent_search_query": last_torrent_search_query,
             "relations": relations,
             "active_nav": "library",
             "page_title": anime.get("title") if isinstance(anime, dict) else None,
             "trailer_embed": trailer_embed,
-            "anime_torrents": anime_torrents,
-            "episode_files": episode_files,
+            "alt_titles": alt_titles,
+            "detail_genre_tags": detail_genre_tags,
+            "detail_airing_fields": detail_airing_fields,
+            "detail_metadata_fields": detail_metadata_fields,
+            "computed_status": computed_status,
+            "computed_status_text": computed_status_text,
+            "computed_status_color": computed_status_color,
         },
+    )
+
+
+@router.get("/ui/anime/{anime_id}/characters", name="web_anime_characters")
+def web_anime_characters(request: Request, anime_id: int) -> HTMLResponse:
+    """Cast list from ``characterRelations`` + ``characters`` tables."""
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
+    sdk = get_sdk()
+    try:
+        anime = sdk.get_anime(anime_id)
+    except NotFoundError:
+        return _render(
+            request,
+            "error.html",
+            {
+                "status_code": 404,
+                "status_text": "Not Found",
+                "detail": f"No anime with id {anime_id}.",
+                "active_nav": "library",
+            },
+            status_code=404,
+        )
+
+    characters: list[dict[str, Any]] = []
+    try:
+        characters = list(sdk.list_anime_characters(anime_id) or [])
+    except Exception:  # noqa: BLE001
+        _LOG.debug("list_anime_characters failed", exc_info=True)
+
+    page_title = None
+    if isinstance(anime, dict):
+        title = anime.get("title")
+        if title:
+            page_title = f"Characters · {title}"
+
+    return _render(
+        request,
+        "anime_characters.html",
+        {
+            "anime": anime,
+            "characters": characters,
+            "active_nav": "library",
+            "page_title": page_title,
+        },
+    )
+
+
+@router.get("/ui/anime/{anime_id}/episodes-panel", name="web_anime_episodes_panel")
+def web_anime_episodes_panel(request: Request, anime_id: int) -> HTMLResponse:
+    """HTMX lazy fragment: episode files + torrent rows (heavy ffprobe work)."""
+    sdk = get_sdk()
+    try:
+        sdk.get_anime(anime_id)
+    except NotFoundError:
+        return HTMLResponse(
+            '<p class="meta">Anime not found.</p>',
+            status_code=404,
+        )
+    return _render(
+        request,
+        "partials/anime_episode_player.html",
+        _anime_episodes_panel_context(sdk, anime_id),
     )
 
 
@@ -869,6 +1477,9 @@ def web_anime_watch(
     anime_id: int,
     file_id: str = "",
 ) -> HTMLResponse:
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     sdk = get_sdk()
     try:
         anime = sdk.get_anime(anime_id)
@@ -984,6 +1595,58 @@ def web_action_seen(
     return _anime_actions_response(request, anime_id)
 
 
+@router.post("/ui/anime/{anime_id}/refresh", name="web_action_refresh_anime")
+def web_action_refresh_anime(request: Request, anime_id: int) -> Response:
+    sdk = get_sdk()
+    try:
+        getattr(sdk, "refresh_anime_metadata", lambda _id: None)(anime_id)
+    except Exception as exc:  # noqa: BLE001
+        _LOG.warning("refresh_anime_metadata failed: %s", exc)
+    return _redirect(f"/ui/anime/{anime_id}")
+
+
+@router.post("/ui/anime/{anime_id}/redownload", name="web_action_redownload")
+def web_action_redownload(request: Request, anime_id: int) -> Response:
+    sdk = get_sdk()
+    try:
+        getattr(sdk, "redownload", lambda _id: 0)(anime_id)
+    except Exception as exc:  # noqa: BLE001
+        _LOG.warning("redownload failed: %s", exc)
+    return _redirect(f"/ui/anime/{anime_id}")
+
+
+@router.post("/ui/anime/{anime_id}/delete-seen", name="web_action_delete_seen_episodes")
+def web_action_delete_seen_episodes(request: Request, anime_id: int) -> Response:
+    sdk = get_sdk()
+    try:
+        getattr(sdk, "delete_seen_episodes", lambda _id, _uid: 0)(
+            anime_id, DEFAULT_USER_ID
+        )
+    except Exception as exc:  # noqa: BLE001
+        _LOG.warning("delete_seen_episodes failed: %s", exc)
+    return _redirect(f"/ui/anime/{anime_id}")
+
+
+@router.post("/ui/anime/{anime_id}/delete-files", name="web_action_delete_all_files")
+def web_action_delete_all_files(request: Request, anime_id: int) -> Response:
+    sdk = get_sdk()
+    try:
+        getattr(sdk, "delete_all_files", lambda _id, _uid: 0)(anime_id, DEFAULT_USER_ID)
+    except Exception as exc:  # noqa: BLE001
+        _LOG.warning("delete_all_files failed: %s", exc)
+    return _redirect(f"/ui/anime/{anime_id}")
+
+
+@router.post("/ui/anime/{anime_id}/remove", name="web_action_remove_anime")
+def web_action_remove_anime(request: Request, anime_id: int) -> Response:
+    sdk = get_sdk()
+    try:
+        getattr(sdk, "delete_anime", lambda _id: False)(anime_id)
+    except Exception as exc:  # noqa: BLE001
+        _LOG.warning("delete_anime failed: %s", exc)
+    return _redirect("/ui/library")
+
+
 @router.post("/ui/anime/{anime_id}/episode-progress", name="web_action_episode_progress")
 def web_action_episode_progress(
     request: Request,
@@ -1024,6 +1687,68 @@ def web_action_episode_delete(
         sdk.delete_episode_file(anime_id, file_id=file_id, user_id=DEFAULT_USER_ID)
     except Exception as exc:  # noqa: BLE001
         _LOG.warning("delete_episode_file failed: %s", exc)
+    return _episode_player_response(request, anime_id)
+
+
+@router.post("/ui/anime/{anime_id}/episode-mark-seen", name="web_action_episode_mark_seen")
+def web_action_episode_mark_seen(
+    request: Request,
+    anime_id: int,
+    file_id: str = Form(""),
+) -> Response:
+    sdk = get_sdk()
+    fid = str(file_id or "").strip()
+    if fid:
+        try:
+            sdk.set_episode_progress(
+                anime_id,
+                user_id=DEFAULT_USER_ID,
+                file_id=fid,
+                status="SEEN",
+                position_seconds=None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _LOG.warning("episode mark seen failed: %s", exc)
+    return _episode_player_response(request, anime_id)
+
+
+@router.post("/ui/anime/{anime_id}/episode-mark-unseen", name="web_action_episode_mark_unseen")
+def web_action_episode_mark_unseen(
+    request: Request,
+    anime_id: int,
+    file_id: str = Form(""),
+) -> Response:
+    sdk = get_sdk()
+    fid = str(file_id or "").strip()
+    if fid:
+        try:
+            sdk.set_episode_progress(
+                anime_id,
+                user_id=DEFAULT_USER_ID,
+                file_id=fid,
+                status="UNSEEN",
+                position_seconds=0.0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _LOG.warning("episode mark unseen failed: %s", exc)
+    return _episode_player_response(request, anime_id)
+
+
+@router.post("/ui/anime/{anime_id}/episode-redownload", name="web_action_episode_redownload")
+def web_action_episode_redownload(
+    request: Request,
+    anime_id: int,
+    file_id: str = Form(""),
+) -> Response:
+    sdk = get_sdk()
+    fid = str(file_id or "").strip()
+    if fid:
+        try:
+            getattr(sdk, "redownload_episode", lambda *_a, **_k: False)(
+                anime_id, fid, DEFAULT_USER_ID
+            )
+        except Exception as exc:  # noqa: BLE001
+            _LOG.warning("episode redownload failed: %s", exc)
     return _episode_player_response(request, anime_id)
 
 
@@ -1426,6 +2151,9 @@ def _overview_counts(overview: dict[str, list[dict[str, Any]]]) -> dict[str, int
 
 @router.get("/ui/downloads", name="web_downloads")
 def web_downloads(request: Request) -> HTMLResponse:
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     sdk = get_sdk()
     overview = _load_torrents_overview(sdk)
     return _render(
@@ -1556,6 +2284,7 @@ async def web_downloads_ws(websocket: WebSocket) -> None:
 
 @router.post("/ui/anime/{anime_id}/download", name="web_action_start_download")
 def web_action_start_download(
+    request: Request,
     anime_id: int,
     url: str | None = Form(None),
     hash_value: str | None = Form(None),
@@ -1570,17 +2299,17 @@ def web_action_start_download(
         )
     except Exception as exc:  # noqa: BLE001
         _LOG.warning("start_download failed: %s", exc)
-    return _redirect("/ui/downloads")
+    return _redirect(_post_download_redirect_path(request, anime_id))
 
 
 @router.post("/ui/anime/{anime_id}/cancel", name="web_action_cancel")
-def web_action_cancel(anime_id: int) -> RedirectResponse:
+def web_action_cancel(request: Request, anime_id: int) -> RedirectResponse:
     sdk = get_sdk()
     try:
         sdk.cancel_download(anime_id)
     except Exception as exc:  # noqa: BLE001
         _LOG.warning("cancel_download failed: %s", exc)
-    return _redirect("/ui/downloads")
+    return _redirect(_post_download_redirect_path(request, anime_id))
 
 
 # ---------------------------------------------------------------------------
@@ -1594,6 +2323,9 @@ def web_torrents(
     term: str | None = None,
     anime_id: int | None = None,
 ) -> HTMLResponse:
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     sdk = get_sdk()
     results: list[dict[str, Any]] = []
     term_clean = (term or "").strip()
@@ -1618,30 +2350,41 @@ def web_torrents(
     )
 
 
-def _resolve_anime_search_term(sdk: ClientSDK, anime_id: int, raw_term: str | None) -> tuple[str, bool]:
-    """Return ``(term, fallback_used)`` for the inline torrent search.
+def _resolve_anime_search_term(
+    sdk: ClientSDK, anime_id: int, raw_term: str | None
+) -> tuple[str, str]:
+    """Return ``(term_clean, torrent_term_source)`` for the inline torrent search.
 
-    Empty / whitespace-only ``raw_term`` falls back to the anime's saved
-    search terms; if none are saved, the anime title is used. This is
-    extracted because both the synchronous partial and the SSE stream
-    need the same resolution logic so they never diverge.
+    Empty / whitespace-only ``raw_term`` falls back in order to: the last
+    successful torrent query for this anime; saved search terms
+    (``title_synonyms`` rows); then the main title plus alternate titles.
+    ``torrent_term_source`` is ``explicit``, ``memory``, ``saved``,
+    ``title``, or ``none``.
     """
     term_clean = (raw_term or "").strip()
     if term_clean:
-        return term_clean, False
+        return term_clean, "explicit"
+    try:
+        last = sdk.get_last_torrent_search_query(anime_id)
+    except Exception:  # noqa: BLE001
+        last = None
+    if last and str(last).strip():
+        return str(last).strip(), "memory"
     try:
         saved = list(sdk.get_search_terms(anime_id) or [])
     except Exception:  # noqa: BLE001
         saved = []
     if saved:
-        return ", ".join(saved), True
+        return ", ".join(saved), "saved"
     try:
         anime = sdk.get_anime(anime_id)
     except Exception:  # noqa: BLE001
-        return "", False
-    if isinstance(anime, dict) and anime.get("title"):
-        return str(anime["title"]).strip(), True
-    return "", False
+        return "", "none"
+    if isinstance(anime, dict):
+        variants = title_variants_for_torrent_search(anime)
+        if variants:
+            return ", ".join(variants), "title"
+    return "", "none"
 
 
 @router.get("/ui/anime/{anime_id}/torrents", name="web_anime_torrent_search")
@@ -1655,21 +2398,22 @@ def web_anime_torrent_search(
     Returns the ``partials/anime_torrent_results.html`` skeleton so the
     anime detail page can swap it in-place. The skeleton wires a live
     SSE connection to :func:`web_anime_torrent_stream`; rows are then
-    appended progressively as engines respond.
+    streamed after the search completes, ordered by seed count.
 
     When ``term`` is empty we fall back to the anime's saved search
-    terms (if any) and finally to its title.
+    terms (if any) and finally to its title and alternate titles.
     """
     sdk = get_sdk()
-    term_clean, fallback_used = _resolve_anime_search_term(sdk, anime_id, term)
+    term_clean, torrent_term_source = _resolve_anime_search_term(sdk, anime_id, term)
     return _render(
         request,
         "partials/anime_torrent_results.html",
         {
             "term": term_clean,
+            "torrent_term_source": torrent_term_source,
             "anime_id": anime_id,
-            "fallback_used": fallback_used,
             "search_error": None,
+            "stream_limit": TORRENT_RESULT_LIMIT,
         },
     )
 
@@ -1685,12 +2429,11 @@ def web_anime_torrent_stream(
     Pushes one ``event: row`` per result (a ready-to-render HTML
     ``<tr>``) as soon as the underlying engines emit it, then a final
     ``event: end`` once the search completes (or a single
-    ``event: error`` if validation fails). The endpoint never
-    materializes the result list, so the user sees the first hits well
-    before the slowest engine finishes.
+    ``event: error`` if validation fails). The client applies the
+    top-k-by-seeds cap in real time while rows stream in.
     """
     sdk = get_sdk()
-    term_clean, _fallback = _resolve_anime_search_term(sdk, anime_id, term)
+    term_clean, _torrent_term_source = _resolve_anime_search_term(sdk, anime_id, term)
 
     def event_stream() -> Iterable[bytes]:
         if not term_clean:
@@ -1708,6 +2451,7 @@ def web_anime_torrent_stream(
         yield b": stream-open\n\n"
 
         emitted = 0
+        stream_failed = False
         try:
             for raw in sdk.stream_torrents(
                 terms, profile="interactive", limit=TORRENT_RESULT_LIMIT
@@ -1723,13 +2467,20 @@ def web_anime_torrent_stream(
                 yield _sse_event("row", html)
                 emitted += 1
         except ValidationError as exc:
+            stream_failed = True
             yield _sse_event("error", str(exc))
         except Exception as exc:  # noqa: BLE001
+            stream_failed = True
             _LOG.warning("inline torrent stream failed: %s", exc)
             yield _sse_event(
                 "error",
                 "Torrent search failed; check the search engines configuration.",
             )
+        if not stream_failed:
+            try:
+                sdk.set_last_torrent_search_query(anime_id, term_clean)
+            except Exception:  # noqa: BLE001
+                _LOG.debug("persist last torrent query failed", exc_info=True)
         yield _sse_event("end", str(emitted))
 
     return StreamingResponse(
@@ -1838,6 +2589,9 @@ def _settings_context(
 
 @router.get("/ui/settings", name="web_settings")
 def web_settings(request: Request) -> HTMLResponse:
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     sdk = get_sdk()
     try:
         current = sdk.get_settings() or {}
@@ -2011,6 +2765,9 @@ def web_logs(
     immediately; the JS layer then upgrades the page by subscribing
     to :func:`web_logs_stream` for live tail updates.
     """
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     # Pick up any settings.json change since the last visit. Cheap on
     # every render because the SDK caches the parsed file.
     _sync_log_buffer_from_settings_safe()
@@ -2319,6 +3076,9 @@ def web_offline(request: Request) -> HTMLResponse:
     The page is intentionally standalone (inline styles, no external
     JS) so it renders even when no other asset is cached.
     """
+    maybe = _next_ui_redirect_for_request(request)
+    if maybe is not None:
+        return maybe
     return templates.TemplateResponse(
         "offline.html",
         {"request": request},

--- a/clients/sdk.py
+++ b/clients/sdk.py
@@ -65,6 +65,18 @@ class ClientSDK:
     def get_anime(self, anime_id: int) -> dict[str, Any]:
         return asdict(self._facade.get_anime_details(anime_id))
 
+    def refresh_anime_metadata(self, anime_id: int) -> dict[str, Any]:
+        return asdict(self._facade.refresh_anime_metadata(anime_id))
+
+    def delete_anime(self, anime_id: int) -> bool:
+        return bool(self._facade.delete_anime(anime_id))
+
+    def get_anime_folder(self, anime_id: int) -> str:
+        getter = getattr(self._facade, "get_anime_folder", None)
+        if not callable(getter):
+            return ""
+        return str(getter(anime_id) or "")
+
     def start_download(
         self,
         anime_id: int,
@@ -79,6 +91,12 @@ class ClientSDK:
 
     def cancel_download(self, anime_id: int) -> bool:
         return self._facade.cancel_download(anime_id)
+
+    def redownload(self, anime_id: int) -> int:
+        runner = getattr(self._facade, "redownload", None)
+        if not callable(runner):
+            return 0
+        return int(runner(anime_id) or 0)
 
     def get_active_downloads(self) -> list[dict[str, Any]]:
         return self._facade.get_active_downloads()
@@ -156,6 +174,12 @@ class ClientSDK:
     def remove_search_term(self, anime_id: int, term: str) -> bool:
         return self._facade.remove_search_term(anime_id, term)
 
+    def get_last_torrent_search_query(self, anime_id: int) -> str | None:
+        return self._facade.get_last_torrent_search_query(anime_id)
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str) -> None:
+        self._facade.set_last_torrent_search_query(anime_id, query)
+
     def get_settings(self) -> dict[str, Any]:
         return self._facade.get_settings()
 
@@ -164,6 +188,9 @@ class ClientSDK:
 
     def get_relations(self, anime_id: int, relation_type: str = "anime") -> list[dict[str, Any]]:
         return self._facade.get_relations(anime_id, relation_type)
+
+    def list_anime_characters(self, anime_id: int) -> list[dict[str, Any]]:
+        return list(self._facade.list_anime_characters(anime_id) or [])
 
     def get_anime_torrents(self, anime_id: int) -> list[dict[str, Any]]:
         return self._facade.get_anime_torrents(anime_id)
@@ -192,6 +219,24 @@ class ClientSDK:
 
     def delete_episode_file(self, anime_id: int, file_id: str, user_id: int) -> bool:
         return bool(self._facade.delete_episode_file(anime_id, file_id, user_id))
+
+    def redownload_episode(self, anime_id: int, file_id: str, user_id: int) -> bool:
+        runner = getattr(self._facade, "redownload_episode", None)
+        if not callable(runner):
+            return False
+        return bool(runner(anime_id, file_id, user_id))
+
+    def delete_all_files(self, anime_id: int, user_id: int) -> int:
+        runner = getattr(self._facade, "delete_all_files", None)
+        if not callable(runner):
+            return 0
+        return int(runner(anime_id, user_id) or 0)
+
+    def delete_seen_episodes(self, anime_id: int, user_id: int) -> int:
+        runner = getattr(self._facade, "delete_seen_episodes", None)
+        if not callable(runner):
+            return 0
+        return int(runner(anime_id, user_id) or 0)
 
     def create_playback_session(
         self,

--- a/composition/facade.py
+++ b/composition/facade.py
@@ -100,6 +100,15 @@ class EmbeddedClientFacade:
     def get_anime_details(self, anime_id: int):
         return self._service.get_anime_details(anime_id)
 
+    def refresh_anime_metadata(self, anime_id: int):
+        return self._service.refresh_anime_metadata(anime_id)
+
+    def delete_anime(self, anime_id: int) -> bool:
+        return self._service.delete_anime(anime_id)
+
+    def get_anime_folder(self, anime_id: int) -> str:
+        return self._service.get_anime_folder(anime_id)
+
     def start_download(
         self,
         anime_id: int,
@@ -121,6 +130,9 @@ class EmbeddedClientFacade:
 
     def cancel_download(self, anime_id: int) -> bool:
         return self._service.cancel_download(anime_id)
+
+    def redownload(self, anime_id: int) -> int:
+        return self._service.redownload(anime_id)
 
     def get_active_downloads(self) -> list[dict]:
         return self._service.get_active_downloads()
@@ -167,6 +179,12 @@ class EmbeddedClientFacade:
     def remove_search_term(self, anime_id: int, term: str) -> bool:
         return self._service.remove_search_term(anime_id, term)
 
+    def get_last_torrent_search_query(self, anime_id: int) -> str | None:
+        return self._service.get_last_torrent_search_query(anime_id)
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str) -> None:
+        self._service.set_last_torrent_search_query(anime_id, query)
+
     def get_settings(self) -> dict:
         return self._service.get_settings()
 
@@ -175,6 +193,9 @@ class EmbeddedClientFacade:
 
     def get_relations(self, anime_id: int, relation_type: str = "anime") -> list[dict]:
         return self._service.get_relations(anime_id, relation_type)
+
+    def list_anime_characters(self, anime_id: int) -> list[dict]:
+        return self._service.list_anime_characters(anime_id)
 
     def get_anime_torrents(self, anime_id: int) -> list[dict]:
         return self._service.get_anime_torrents(anime_id)
@@ -200,6 +221,15 @@ class EmbeddedClientFacade:
 
     def delete_episode_file(self, anime_id: int, file_id: str, user_id: int) -> bool:
         return self._service.delete_episode_file(anime_id, file_id, user_id)
+
+    def redownload_episode(self, anime_id: int, file_id: str, user_id: int) -> bool:
+        return self._service.redownload_episode(anime_id, file_id, user_id)
+
+    def delete_all_files(self, anime_id: int, user_id: int) -> int:
+        return self._service.delete_all_files(anime_id, user_id)
+
+    def delete_seen_episodes(self, anime_id: int, user_id: int) -> int:
+        return self._service.delete_seen_episodes(anime_id, user_id)
 
     def create_playback_session(
         self,

--- a/docs/developer/nextjs_api_contracts.md
+++ b/docs/developer/nextjs_api_contracts.md
@@ -1,0 +1,87 @@
+# Next.js API Contracts
+
+This document defines the JSON contract used by the Next.js App Router
+frontend during and after `/ui` cutover.
+
+## Contract Principles
+
+- Keep Python as the source of truth for domain logic.
+- Use JSON endpoints for page data and mutations.
+- Keep SSE/WS transport endpoints unchanged for realtime flows.
+- Version the UI API via `/ui/api/meta`.
+
+## New Stable JSON Endpoints
+
+All endpoints are provided by `clients/http/app.py`.
+
+### Metadata and capability discovery
+
+- `GET /ui/api/meta`
+
+Response:
+
+```json
+{
+  "service": "animemanager-http-client-adapter",
+  "ui_api_version": "2026-05-18",
+  "streams": {
+    "library_ws": "/ui/library/ws",
+    "downloads_ws": "/ui/downloads/ws",
+    "torrent_sse": "/ui/anime/{anime_id}/torrents/stream",
+    "logs_sse": "/ui/logs/stream"
+  }
+}
+```
+
+### Library data
+
+- `GET /ui/api/library?q=&filter=DEFAULT&list_start=0&list_stop=50&hide_rated=`
+- Returns `{ mode, query, items, has_next, list_start, list_stop, filter }`.
+- `mode = "search"` when `q` is non-empty; otherwise `mode = "list"`.
+
+### Anime detail bundle
+
+- `GET /ui/api/anime/{anime_id}/bundle?user_id=1`
+- Returns:
+  - `anime`
+  - `state`
+  - `search_terms`
+  - `episodes`
+  - `relations`
+  - `characters`
+  - `last_torrent_query`
+
+### Focused anime resources
+
+- `GET /ui/api/anime/{anime_id}/characters`
+- `GET /ui/api/anime/{anime_id}/episodes?user_id=1`
+
+### Torrents and downloads
+
+- `GET /ui/api/torrents/search?anime_id=&term=&profile=interactive&limit=200`
+- `GET /ui/api/downloads/overview`
+
+### Logs snapshot
+
+- `GET /ui/api/logs?level=INFO&logger=&q=&limit=200&since=0`
+- Returns buffered records compatible with the existing logs UI.
+
+### Mutations
+
+- `POST /ui/api/anime/{anime_id}/like` body: `{ "user_id": 1, "liked": true }`
+- `POST /ui/api/anime/{anime_id}/tag` body: `{ "user_id": 1, "tag": "WATCHING" }`
+- `POST /ui/api/anime/{anime_id}/download` body: `{ "user_id": 1, "url": "...", "hash": "..." }`
+- `POST /ui/api/anime/{anime_id}/cancel`
+
+## Realtime Endpoints (Unchanged)
+
+- Library stream websocket: `/ui/library/ws`
+- Downloads stream websocket: `/ui/downloads/ws`
+- Torrent results SSE: `/ui/anime/{anime_id}/torrents/stream`
+- Logs SSE: `/ui/logs/stream`
+
+## Backward Compatibility
+
+- Existing classic JSON endpoints (`/anime/*`, `/animelist`, `/search`, ...)
+  remain available.
+- Existing server-rendered `/ui/*` pages remain available until cutover.

--- a/docs/developer/operations.rst
+++ b/docs/developer/operations.rst
@@ -5,6 +5,15 @@ This page covers the operational knobs that influence the API->DB
 pipeline at runtime: feature flags, secret provisioning, database
 bootstrap, and rollback procedures.
 
+Stability gate
+--------------
+
+Before merging refactor work, run the mandatory stability gate::
+
+   python scripts/stability_gate.py
+
+See :doc:`stability-slos` for SLO targets and critical user journeys.
+
 Feature flags
 -------------
 

--- a/docs/developer/testing.rst
+++ b/docs/developer/testing.rst
@@ -11,6 +11,17 @@ fast.
 
 This page is the canonical answer to *"which tests do I run when?"*
 
+Stability gate (refactor program)
+---------------------------------
+
+During the stability refactor, run the mandatory gate before every merge
+that touches metadata ingestion, provider adapters, or layer boundaries::
+
+   python scripts/stability_gate.py
+
+The gate runs ``pytest -m architecture`` plus the critical metadata
+pipeline unit slice. See :doc:`stability-slos` for SLO targets.
+
 Test layout
 -----------
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -30,6 +30,7 @@ markers =
     memory: marks tests for memory usage analysis
     load: marks tests for load and concurrency testing
     architecture: marks architecture/layer-boundary tests (run with -m architecture)
+    stability_gate: marks tests included in scripts/stability_gate.py
 
 filterwarnings =
     ignore::DeprecationWarning

--- a/tests/gui/test_tk_smoke.py
+++ b/tests/gui/test_tk_smoke.py
@@ -61,6 +61,13 @@ class FakeSDK:
         _ = (anime_id, term)
         return True
 
+    def get_last_torrent_search_query(self, anime_id: int):
+        _ = anime_id
+        return None
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str):
+        _ = (anime_id, query)
+
     def get_settings(self):
         return {"anime": {"hideRated": True}}
 

--- a/tests/unit/backend/test_application_service.py
+++ b/tests/unit/backend/test_application_service.py
@@ -30,6 +30,13 @@ class FakeRepository:
         _ = anime_id
         return bool(term)
 
+    def get_last_torrent_search_query(self, anime_id: int):
+        _ = anime_id
+        return None
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str):
+        _ = (anime_id, query)
+
     def get_settings(self):
         return {"anime": {"hideRated": True}}
 
@@ -40,6 +47,17 @@ class FakeRepository:
         _ = (anime_id, relation_type)
         return [{"id": 1, "rel_id": 2, "name": "SEQUEL"}]
 
+    def list_anime_characters(self, anime_id: int):
+        _ = anime_id
+        return [{"id": 1, "name": "Renji", "role": "supporting", "picture": None, "synopsis": None}]
+
+    def delete_anime(self, anime_id: int):
+        _ = anime_id
+        return True
+
+    def get_anime_folder(self, anime_id: int):
+        return f"/anime/{anime_id}"
+
 
 class FakeProvider:
     def search(self, query: str, limit: int = 50):
@@ -47,6 +65,9 @@ class FakeProvider:
         if query == "naruto":
             return [AnimeEntity(id=2, title="Naruto", status="FINISHED")]
         return []
+
+    def refresh_anime(self, anime_id: int):
+        return AnimeEntity(id=anime_id, title="Refreshed", status="AIRING")
 
 
 class FakeDownload:
@@ -67,6 +88,10 @@ class FakeDownload:
     def search_torrents(self, terms, profile="interactive", limit=200):
         _ = (profile, limit)
         return [{"name": "result", "terms": terms}]
+
+    def redownload(self, anime_id: int):
+        _ = anime_id
+        return 1
 
 
 class FakeActions:
@@ -162,3 +187,8 @@ def test_extended_contract_use_cases():
     assert service.get_settings()["anime"]["hideRated"] is True
     assert service.update_settings({"anime": {"hideRated": False}})["anime"]["hideRated"] is False
     assert service.get_relations(1)[0]["name"] == "SEQUEL"
+    assert service.list_anime_characters(1)[0]["name"] == "Renji"
+    assert service.redownload(1) == 1
+    assert service.delete_anime(1) is True
+    assert service.get_anime_folder(1) == "/anime/1"
+    assert service.refresh_anime_metadata(1).title == "Refreshed"

--- a/tests/unit/backend/test_application_service_edges.py
+++ b/tests/unit/backend/test_application_service_edges.py
@@ -23,6 +23,7 @@ class FakeRepository:
         self.items = []
         self.calls = []
         self.return_search_terms = ["term"]
+        self.last_torrent_query: dict[int, str] = {}
 
     def search(self, query, limit=50):
         self.calls.append(("search", query, limit))
@@ -51,6 +52,14 @@ class FakeRepository:
         self.calls.append(("remove_search_term", anime_id, term))
         return True
 
+    def get_last_torrent_search_query(self, anime_id):
+        self.calls.append(("get_last_torrent_search_query", anime_id))
+        return self.last_torrent_query.get(anime_id)
+
+    def set_last_torrent_search_query(self, anime_id, query):
+        self.calls.append(("set_last_torrent_search_query", anime_id, query))
+        self.last_torrent_query[anime_id] = query
+
     def get_settings(self):
         return {"anime": {"hideRated": True}}
 
@@ -58,6 +67,10 @@ class FakeRepository:
         return updates
 
     def get_relations(self, anime_id, relation_type="anime"):
+        return []
+
+    def list_anime_characters(self, anime_id):
+        self.calls.append(("list_anime_characters", anime_id))
         return []
 
 
@@ -72,6 +85,8 @@ class FakeProvider:
 class FakeDownload:
     def __init__(self):
         self.start_calls = []
+        self.search_rows = [{}]
+        self.stream_rows = []
 
     def start_download(self, anime_id, url=None, hash_value=None, user_id=None):
         self.start_calls.append((anime_id, url, hash_value, user_id))
@@ -87,7 +102,28 @@ class FakeDownload:
         return []
 
     def search_torrents(self, terms, profile="interactive", limit=200):
-        return [{"terms": list(terms), "profile": profile, "limit": limit}]
+        rows = []
+        for row in self.search_rows:
+            if isinstance(row, dict):
+                merged = dict(row)
+                merged.setdefault("terms", list(terms))
+                merged.setdefault("profile", profile)
+                merged.setdefault("limit", limit)
+                rows.append(merged)
+            else:
+                rows.append(row)
+        return rows
+
+    def stream_torrents(self, terms, profile="interactive", limit=200):
+        for row in self.stream_rows:
+            if isinstance(row, dict):
+                merged = dict(row)
+                merged.setdefault("terms", list(terms))
+                merged.setdefault("profile", profile)
+                merged.setdefault("limit", limit)
+                yield merged
+            else:
+                yield row
 
 
 class FakeActions:
@@ -255,6 +291,47 @@ class TestSearchTorrentsEdges:
         out = service.search_torrents([None, "valid"])
         assert "valid" in out[0]["terms"]
 
+    def test_dedupes_materialized_results_by_infohash(self, service):
+        _, _, dl, _ = service._fakes
+        dl.search_rows = [
+            {"name": "from provider A", "infohash": "abc123"},
+            {"name": "from provider B", "hash": "ABC123"},
+            {"name": "different", "infohash": "def456"},
+        ]
+        out = service.search_torrents(["naruto"])
+        assert [row["name"] for row in out] == ["from provider A", "different"]
+
+    def test_dedupes_materialized_results_with_base32_vs_hex(self, service):
+        _, _, dl, _ = service._fakes
+        dl.search_rows = [
+            {"name": "hex", "infohash": "0123456789abcdef0123456789abcdef01234567"},
+            {"name": "base32", "infohash": "AERUKZ4JVPG66AJDIVTYTK6N54ASGRLH"},
+        ]
+        out = service.search_torrents(["naruto"])
+        assert [row["name"] for row in out] == ["hex"]
+
+    def test_dedupes_materialized_results_by_magnet_xt_hash(self, service):
+        _, _, dl, _ = service._fakes
+        dl.search_rows = [
+            {"name": "first", "link": "magnet:?xt=urn:btih:abc123"},
+            {"name": "dup", "link": "magnet:?xt=urn:btih:ABC123&dn=test"},
+            {"name": "other", "link": "magnet:?xt=urn:btih:def456"},
+        ]
+        out = service.search_torrents(["naruto"])
+        assert [row["name"] for row in out] == ["first", "other"]
+
+
+class TestStreamTorrentsEdges:
+    def test_stream_dedupes_by_hash_without_buffering(self, service):
+        _, _, dl, _ = service._fakes
+        dl.stream_rows = [
+            {"name": "first", "infohash": "abc"},
+            {"name": "dup", "hash": "ABC"},
+            {"name": "second", "infohash": "def"},
+        ]
+        out = list(service.stream_torrents(["bleach"]))
+        assert [row["name"] for row in out] == ["first", "second"]
+
 
 # ---------------------------------------------------------------------------
 # add / remove search term
@@ -378,3 +455,10 @@ class TestPortPassThrough:
     def test_get_search_terms_returns_list(self, service):
         out = service.get_search_terms(1)
         assert isinstance(out, list)
+
+    def test_last_torrent_search_query_round_trip(self, service):
+        repo, _, _, _ = service._fakes
+        assert service.get_last_torrent_search_query(1) is None
+        service.set_last_torrent_search_query(1, "a, b")
+        assert ("set_last_torrent_search_query", 1, "a, b") in repo.calls
+        assert service.get_last_torrent_search_query(1) == "a, b"

--- a/tests/unit/clients/test_http_adapter.py
+++ b/tests/unit/clients/test_http_adapter.py
@@ -60,6 +60,13 @@ class FakeSDK:
         _ = (anime_id, term)
         return True
 
+    def get_last_torrent_search_query(self, anime_id: int):
+        _ = anime_id
+        return None
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str):
+        _ = (anime_id, query)
+
     def get_settings(self):
         return {"anime": {"hideRated": True}}
 

--- a/tests/unit/clients/test_http_api_comprehensive.py
+++ b/tests/unit/clients/test_http_api_comprehensive.py
@@ -140,6 +140,16 @@ class RecordingSDK:
             "remove_search_term", (anime_id, term), {}, default=lambda: True
         )
 
+    def get_last_torrent_search_query(self, anime_id: int):
+        return self._invoke(
+            "get_last_torrent_search_query", (anime_id,), {}, default=lambda: None
+        )
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str):
+        return self._invoke(
+            "set_last_torrent_search_query", (anime_id, query), {}, default=lambda: None
+        )
+
     def update_settings(self, updates):
         return self._invoke(
             "update_settings", (updates,), {}, default=lambda: updates

--- a/tests/unit/clients/test_http_app_edges.py
+++ b/tests/unit/clients/test_http_app_edges.py
@@ -70,6 +70,12 @@ class _SDKBase:
     def remove_search_term(self, anime_id, term):
         return True
 
+    def get_last_torrent_search_query(self, anime_id):
+        return None
+
+    def set_last_torrent_search_query(self, anime_id, query):
+        pass
+
     def get_settings(self):
         return {}
 

--- a/tests/unit/clients/test_http_log_buffer.py
+++ b/tests/unit/clients/test_http_log_buffer.py
@@ -1,0 +1,273 @@
+"""Unit tests for :mod:`clients.http.log_buffer`."""
+
+from __future__ import annotations
+
+import logging
+import queue
+import time
+
+import pytest
+
+from clients.http import log_buffer as lb
+
+
+def test_derive_category_from_legacy_bracket():
+    payload = {"message": "[ MAIN_STATE ] - pipeline started", "logger": "x"}
+    assert lb.derive_category(payload) == "MAIN_STATE"
+
+
+def test_derive_category_from_logger_prefix():
+    payload = {
+        "message": "fetch ok",
+        "logger": "application.services.download_manager.worker",
+        "levelno": logging.INFO,
+    }
+    assert lb.derive_category(payload) == "DOWNLOAD"
+
+
+def test_derive_category_db_error_on_high_level():
+    payload = {
+        "message": "write failed",
+        "logger": "adapters.persistence.db",
+        "levelno": logging.ERROR,
+    }
+    assert lb.derive_category(payload) == "DB_ERROR"
+
+
+def test_strip_legacy_bracket():
+    clean, cat = lb.strip_legacy_bracket("[ NETWORK ] - timeout")
+    assert cat == "NETWORK"
+    assert clean == "timeout"
+    assert lb.strip_legacy_bracket("plain text") == ("plain text", None)
+
+
+def test_log_buffer_add_and_snapshot_filters():
+    buf = lb.LogBuffer(max_records=10)
+    buf.add(
+        {
+            "levelno": logging.INFO,
+            "level": "INFO",
+            "logger": "tests.unit",
+            "message": "hello",
+            "category": "HTTP",
+        }
+    )
+    buf.add(
+        {
+            "levelno": logging.ERROR,
+            "level": "ERROR",
+            "logger": "tests.unit",
+            "message": "boom",
+            "category": "HTTP",
+        }
+    )
+    errors = buf.snapshot(min_level=logging.ERROR)
+    assert len(errors) == 1
+    assert errors[0]["message"] == "boom"
+
+
+def test_disabled_categories_drop_records():
+    buf = lb.LogBuffer()
+    buf.set_disabled_categories(["HTTP"])
+    stored = buf.add(
+        {
+            "levelno": logging.INFO,
+            "message": "hidden",
+            "category": "HTTP",
+        }
+    )
+    assert stored is None
+    assert buf.snapshot() == []
+
+
+def test_subscribe_receives_broadcast():
+    buf = lb.LogBuffer()
+    sub = buf.subscribe(maxsize=5)
+    try:
+        buf.add({"levelno": logging.INFO, "message": "live", "category": "OTHER"})
+        item = sub.get(timeout=1.0)
+        assert item["message"] == "live"
+        assert "id" in item
+    finally:
+        buf.unsubscribe(sub)
+
+
+def test_subscribe_drops_oldest_on_overflow():
+    buf = lb.LogBuffer()
+    sub = buf.subscribe(maxsize=1)
+    try:
+        buf.add({"levelno": logging.INFO, "message": "first", "category": "OTHER"})
+        buf.add({"levelno": logging.INFO, "message": "second", "category": "OTHER"})
+        latest = sub.get_nowait()
+        assert latest["message"] in {"first", "second"}
+    finally:
+        buf.unsubscribe(sub)
+
+
+def test_sync_from_settings_whitelist():
+    buf = lb.LogBuffer()
+    disabled = lb.sync_from_settings(
+        {"logs": {"enabled_categories": ["HTTP", "SEARCH"]}},
+        buffer=buf,
+    )
+    assert "MAIN_STATE" in disabled
+    assert "HTTP" not in disabled
+
+
+def test_buffering_handler_emit_strips_bracket_category():
+    buf = lb.LogBuffer()
+    handler = lb.BufferingHandler(buf, level=logging.DEBUG)
+    record = logging.LogRecord(
+        name="bootstrap",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="[ STARTUP ] - ready",
+        args=(),
+        exc_info=None,
+    )
+    handler.emit(record)
+    snap = buf.snapshot()
+    assert len(snap) == 1
+    assert snap[0]["category"] == "STARTUP"
+    assert snap[0]["message"] == "ready"
+
+
+def test_stream_filtered_yields_heartbeat_on_timeout():
+    buf = lb.LogBuffer()
+    sub = queue.Queue()
+    gen = lb.stream_filtered(sub, timeout=0.01)
+    item = next(gen)
+    assert item is None
+
+
+def test_level_value_coercion():
+    assert lb._level_value("INFO") == logging.INFO
+    assert lb._level_value(30) == 30
+    assert lb._level_value("", default=logging.WARNING) == logging.WARNING
+    assert lb._level_value("not-a-level", default=logging.ERROR) == logging.ERROR
+
+
+def test_clear_and_latest_id():
+    buf = lb.LogBuffer()
+    assert buf.latest_id() == 0
+    stored = buf.add({"levelno": logging.INFO, "message": "one", "category": "OTHER"})
+    assert stored is not None
+    assert buf.latest_id() == stored["id"]
+    assert buf.clear() == 1
+    assert buf.snapshot() == []
+    assert buf.latest_id() == 0
+
+
+def test_known_categories_includes_observed_extras():
+    buf = lb.LogBuffer()
+    buf.add({"levelno": logging.INFO, "message": "x", "category": "CUSTOM_CAT"})
+    cats = buf.known_categories()
+    assert "CUSTOM_CAT" in cats
+    assert cats.index("HTTP") < cats.index("CUSTOM_CAT")
+
+
+def test_snapshot_filters_logger_text_and_categories():
+    buf = lb.LogBuffer()
+    buf.add(
+        {
+            "levelno": logging.INFO,
+            "logger": "adapters.api.jikan",
+            "module": "client",
+            "message": "fetch ok",
+            "category": "NETWORK",
+        }
+    )
+    buf.add(
+        {
+            "levelno": logging.ERROR,
+            "logger": "other",
+            "message": "boom",
+            "category": "OTHER",
+            "exc_info": "Traceback\nline",
+        }
+    )
+    assert len(buf.snapshot(logger_substr="jikan")) == 1
+    assert len(buf.snapshot(text="Traceback")) == 1
+    assert len(buf.snapshot(categories=["NETWORK"])) == 1
+    assert len(buf.snapshot(min_level=logging.ERROR)) == 1
+    assert len(buf.snapshot(limit=1)) == 1
+
+
+def test_sync_from_settings_missing_key_clears_disabled():
+    buf = lb.LogBuffer()
+    buf.set_disabled_categories(["HTTP"])
+    disabled = lb.sync_from_settings({"logs": {}}, buffer=buf)
+    assert disabled == set()
+
+
+def test_sync_from_settings_empty_enabled_silences_all():
+    buf = lb.LogBuffer()
+    disabled = lb.sync_from_settings(
+        {"logs": {"enabled_categories": []}},
+        buffer=buf,
+    )
+    assert "HTTP" in disabled
+    assert buf.add({"levelno": logging.INFO, "message": "x", "category": "HTTP"}) is None
+
+
+def test_stream_filtered_passes_matching_records():
+    sub = queue.Queue()
+    sub.put(
+        {
+            "levelno": logging.WARNING,
+            "message": "warn",
+            "category": "DOWNLOAD",
+        }
+    )
+    gen = lb.stream_filtered(sub, min_level=logging.INFO, categories=["DOWNLOAD"], timeout=0.01)
+    record = next(gen)
+    assert record is not None
+    assert record["message"] == "warn"
+
+
+def test_buffering_handler_captures_exc_info():
+    import sys
+
+    buf = lb.LogBuffer()
+    handler = lb.BufferingHandler(buf, level=logging.DEBUG)
+    try:
+        raise ValueError("kaboom")
+    except ValueError:
+        exc_info = sys.exc_info()
+    record = logging.LogRecord(
+        name="tests",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="failed",
+        args=(),
+        exc_info=exc_info,
+    )
+    handler.emit(record)
+    snap = buf.snapshot()
+    assert snap[0]["exc_info"]
+    assert "ValueError" in snap[0]["exc_info"]
+
+
+def test_install_returns_same_handler_twice():
+    root = logging.getLogger()
+    before = [h for h in root.handlers if isinstance(h, lb.BufferingHandler)]
+    first = lb.install(buffer=lb.LogBuffer(), capture_root=False)
+    second = lb.install(buffer=lb.LogBuffer(), capture_root=False)
+    assert first is second
+    for extra in [h for h in root.handlers if isinstance(h, lb.BufferingHandler)]:
+        if extra not in before:
+            root.removeHandler(extra)
+
+
+def test_iter_records_reads_snapshot():
+    buf = lb.LogBuffer()
+    buf.add({"levelno": logging.INFO, "message": "snap", "category": "OTHER"})
+    rows = list(lb.iter_records(buf))
+    assert rows[0]["message"] == "snap"
+
+
+def test_derive_category_clients_http_prefix():
+    payload = {"message": "req", "logger": "clients.http.web"}
+    assert lb.derive_category(payload) == "HTTP"

--- a/tests/unit/clients/test_http_settings_form.py
+++ b/tests/unit/clients/test_http_settings_form.py
@@ -1,0 +1,56 @@
+"""Unit tests for :mod:`clients.http.settings_form`."""
+
+from __future__ import annotations
+
+from clients.http import settings_form as sf
+
+
+def _minimal_settings() -> dict:
+    return {
+        "anime": {"hideRated": True, "animePerPage": 50},
+        "logs": {"enabled_categories": ["HTTP", "SEARCH"]},
+        "UI": {
+            "colors": {"Blue": "#56D8EF"},
+            "tagcolors": {"SEEN": "Blue"},
+        },
+    }
+
+
+class _FakeForm(dict):
+    def getlist(self, key: str) -> list[str]:
+        val = self.get(key)
+        if val is None:
+            return []
+        if isinstance(val, list):
+            return val
+        return [val]
+
+
+def test_build_sections_orders_tier_one_first():
+    sections = sf.build_sections(_minimal_settings())
+    names = [s["name"] for s in sections]
+    assert names.index("anime") < names.index("UI")
+
+
+def test_parse_form_bool_unchecked_round_trip():
+    current = _minimal_settings()
+    form = _FakeForm(
+        {
+            "__bool__": "anime.hideRated",
+        }
+    )
+    out = sf.parse_form(form, current)
+    assert out["anime"]["hideRated"] is False
+
+
+def test_parse_form_int_coercion():
+    current = _minimal_settings()
+    form = _FakeForm({"anime.animePerPage": "25"})
+    out = sf.parse_form(form, current)
+    assert out["anime"]["animePerPage"] == 25
+
+
+def test_build_context_exposes_palette():
+    ctx = sf.build_context(_minimal_settings())
+    assert "color_palette" in ctx
+    assert ctx["color_palette"]["Blue"] == "#56D8EF"

--- a/tests/unit/clients/test_http_ui_api.py
+++ b/tests/unit/clients/test_http_ui_api.py
@@ -1,0 +1,118 @@
+"""Tests for the Next.js-oriented ``/ui/api/*`` contract."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+http_app_module = importlib.import_module("clients.http.app")
+
+
+class _SDK:
+    def search_anime(self, query: str, limit: int = 50):
+        return [{"id": 10, "title": query, "limit": limit}]
+
+    def get_anime_list(self, **kwargs):
+        return {"items": [{"id": 1, "title": "A"}], "has_next": False}
+
+    def get_anime(self, anime_id: int):
+        return {"id": anime_id, "title": "Test Anime"}
+
+    def get_user_state(self, anime_id: int, user_id: int):
+        return {"anime_id": anime_id, "user_id": user_id, "liked": False}
+
+    def get_search_terms(self, anime_id: int):
+        return ["term1", "term2"]
+
+    def list_episode_files(self, anime_id: int, user_id: int | None = None):
+        return [{"id": "f1", "name": "episode.mkv"}]
+
+    def get_relations(self, anime_id: int, relation_type: str = "anime"):
+        return [{"id": anime_id + 1, "relation_type": relation_type}]
+
+    def list_anime_characters(self, anime_id: int):
+        return [{"id": 123, "name": "Hero"}]
+
+    def get_last_torrent_search_query(self, anime_id: int):
+        return "old query"
+
+    def search_torrents(self, terms, profile="interactive", limit=200):
+        return [{"name": "torrent", "terms": terms, "profile": profile, "limit": limit}]
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str):
+        self.last_query = (anime_id, query)
+
+    def get_torrents_overview(self):
+        return {"active": [{"name": "one"}], "seeding": [], "completed": [], "error": [], "other": []}
+
+    def set_like(self, anime_id, user_id, liked=True):
+        return None
+
+    def set_tag(self, anime_id, tag, user_id):
+        return None
+
+    def start_download(self, anime_id, url=None, hash_value=None, user_id=None):
+        return True
+
+    def cancel_download(self, anime_id: int):
+        return True
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(http_app_module, "get_sdk", lambda: _SDK())
+    return TestClient(http_app_module.app)
+
+
+def test_ui_api_meta(client):
+    resp = client.get("/ui/api/meta")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ui_api_version"]
+    assert payload["streams"]["library_ws"] == "/ui/library/ws"
+
+
+def test_ui_api_library_list_mode(client):
+    resp = client.get("/ui/api/library", params={"filter": "DEFAULT"})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["mode"] == "list"
+    assert isinstance(payload["items"], list)
+
+
+def test_ui_api_library_search_mode(client):
+    resp = client.get("/ui/api/library", params={"q": "naruto"})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["mode"] == "search"
+    assert payload["query"] == "naruto"
+
+
+def test_ui_api_anime_bundle(client):
+    resp = client.get("/ui/api/anime/7/bundle")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["anime"]["id"] == 7
+    assert "episodes" in payload
+    assert "characters" in payload
+
+
+def test_ui_api_torrent_search(client):
+    resp = client.get("/ui/api/torrents/search", params={"anime_id": 9, "term": "abc"})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["query"] == "abc"
+    assert payload["items"][0]["name"] == "torrent"
+
+
+def test_ui_api_mutations(client):
+    like_resp = client.post("/ui/api/anime/1/like", json={"user_id": 1, "liked": True})
+    tag_resp = client.post("/ui/api/anime/1/tag", json={"user_id": 1, "tag": "WATCHING"})
+    dl_resp = client.post("/ui/api/anime/1/download", json={"user_id": 1, "url": "magnet:?x"})
+    cancel_resp = client.post("/ui/api/anime/1/cancel")
+    assert like_resp.status_code == 200
+    assert tag_resp.status_code == 200
+    assert dl_resp.json() == {"started": True}
+    assert cancel_resp.json() == {"cancelled": True}

--- a/tests/unit/clients/test_http_web_cutover.py
+++ b/tests/unit/clients/test_http_web_cutover.py
@@ -1,0 +1,34 @@
+"""Cutover redirect tests for legacy `/ui/*` pages."""
+
+from __future__ import annotations
+
+import importlib
+
+from fastapi.testclient import TestClient
+
+http_app_module = importlib.import_module("clients.http.app")
+
+
+class _SDK:
+    def get_anime_list(self, **kwargs):
+        return {"items": [], "has_next": False}
+
+
+def test_ui_routes_redirect_to_next_when_cutover_enabled(monkeypatch):
+    monkeypatch.setattr(http_app_module, "get_sdk", lambda: _SDK())
+    monkeypatch.setenv("ANIMEMANAGER_NEXT_UI_URL", "http://127.0.0.1:3000")
+    client = TestClient(http_app_module.app)
+
+    resp = client.get("/ui/library", follow_redirects=False)
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "http://127.0.0.1:3000/library"
+
+
+def test_ui_root_redirects_to_next_root_when_cutover_enabled(monkeypatch):
+    monkeypatch.setattr(http_app_module, "get_sdk", lambda: _SDK())
+    monkeypatch.setenv("ANIMEMANAGER_NEXT_UI_URL", "http://127.0.0.1:3000")
+    client = TestClient(http_app_module.app)
+
+    resp = client.get("/ui", follow_redirects=False)
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "http://127.0.0.1:3000/"

--- a/tests/unit/clients/test_http_web_helpers.py
+++ b/tests/unit/clients/test_http_web_helpers.py
@@ -1,0 +1,240 @@
+"""Unit tests for pure helpers in :mod:`clients.http.web`."""
+
+from __future__ import annotations
+
+import importlib
+import time
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from domain.errors import NotFoundError, UnauthorizedError, ValidationError
+
+http_web = importlib.import_module("clients.http.web")
+
+
+@pytest.fixture(autouse=True)
+def _reset_metadata_refresh_cache():
+    yield
+    http_web._METADATA_REFRESH_TS.clear()
+
+
+class TestSafeIntAndDates:
+    def test_safe_int_defaults_on_bad_input(self):
+        assert http_web._safe_int("nope", 3) == 3
+        assert http_web._safe_int("12", 0) == 12
+
+    def test_format_unix_date(self):
+        assert http_web._format_unix_date(0) is None
+        assert http_web._format_unix_date(1_600_000_000) == "2020-09-13"
+
+    def test_string_list_dedupes_case_insensitive(self):
+        assert http_web._string_list(["Foo", "foo", "bar"]) == ["Foo", "bar"]
+
+
+class TestHumanizeHelpers:
+    def test_humanize_size(self):
+        assert http_web._humanize_size(0) is None
+        assert http_web._humanize_size(1536) == "1.5 KB"
+
+    def test_format_speed_and_eta(self):
+        assert http_web._format_speed(0) is None
+        assert http_web._format_speed(2048) == "2.0 KB/s"
+        assert http_web._format_eta(45) == "45s"
+        assert http_web._format_eta(3661) == "1h 1m"
+
+
+class TestMapError:
+    def test_validation_not_found_unauthorized(self):
+        assert http_web._map_error(ValidationError("bad")) == (400, "bad")
+        assert http_web._map_error(NotFoundError("missing")) == (404, "missing")
+        assert http_web._map_error(UnauthorizedError("nope")) == (401, "nope")
+
+    def test_unknown_error_message(self):
+        code, msg = http_web._map_error(RuntimeError("boom"))
+        assert code == 500
+        assert msg == "Unexpected error"
+
+
+class TestSseAndTorrentNormalization:
+    def test_sse_event_multiline_data(self):
+        frame = http_web._sse_event("html", "line1\nline2").decode("utf-8")
+        assert "event: html" in frame
+        assert "data: line1" in frame
+        assert "data: line2" in frame
+
+    def test_normalize_torrents_adds_size_human(self):
+        rows = http_web._normalize_torrents([{"name": "x", "size": 1024, "seeds": 1}])
+        assert rows[0]["size_human"] == "1.0 KB"
+
+    def test_normalize_overview_row_progress_fraction(self):
+        row = http_web._normalize_overview_row(
+            {"name": "t", "progress": 0.5, "dl_speed": 1024, "eta": 90}
+        )
+        assert row["progress_pct"] == 50.0
+        assert row["dl_speed_human"] == "1.0 KB/s"
+        assert row["eta_human"] == "1m 30s"
+
+
+class TestStreamingClientAllowlist:
+    def _request(self, *, host: str = "127.0.0.1", forwarded: str | None = None):
+        headers: list[tuple[bytes, bytes]] = []
+        if forwarded:
+            headers.append((b"x-forwarded-for", forwarded.encode()))
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": headers,
+            "client": (host, 0),
+        }
+        return http_web.Request(scope)
+
+    def test_client_host_prefers_forwarded(self):
+        req = self._request(host="10.0.0.1", forwarded="203.0.113.5, 10.0.0.1")
+        assert http_web._client_host(req) == "203.0.113.5"
+
+    def test_host_in_allowlist_cidr(self):
+        assert http_web._host_in_allowlist("192.168.1.10", ["192.168.0.0/16"])
+
+    def test_loopback_always_allowed(self):
+        sdk = MagicMock()
+        sdk.get_settings.return_value = {"web": {"player_allow_public": False}}
+        req = self._request(host="127.0.0.1")
+        assert http_web._is_client_allowed_for_streaming(req, sdk) is True
+
+    def test_public_flag_allows_remote(self):
+        sdk = MagicMock()
+        sdk.get_settings.return_value = {"web": {"player_allow_public": True}}
+        req = self._request(host="203.0.113.9")
+        assert http_web._is_client_allowed_for_streaming(req, sdk) is True
+
+
+class TestCollectAnimeTorrents:
+    def test_merges_saved_and_active_by_hash(self):
+        sdk = MagicMock()
+        sdk.get_anime_torrents.return_value = [
+            {"hash": "abc", "name": "saved", "size": 100, "downloaded": 0}
+        ]
+        sdk.get_active_downloads.return_value = [
+            {
+                "anime_id": 7,
+                "hash": "abc",
+                "name": "active",
+                "size": 100,
+                "downloaded": 50,
+                "progress": 0.5,
+            },
+            {"anime_id": 99, "hash": "other", "name": "skip"},
+        ]
+        rows = http_web._collect_anime_torrents(sdk, 7)
+        assert len(rows) == 1
+        assert rows[0]["downloaded"] == 50
+        assert rows[0]["state"] == "DOWNLOADING"
+
+
+class TestMetadataRefreshThrottle:
+    def test_maybe_refresh_skips_within_interval(self, monkeypatch):
+        http_web._METADATA_REFRESH_TS.clear()
+        sdk = MagicMock()
+        http_web._maybe_refresh_anime_metadata(sdk, 42)
+        http_web._maybe_refresh_anime_metadata(sdk, 42)
+        assert sdk.refresh_anime_metadata.call_count == 1
+
+    def test_maybe_refresh_calls_after_interval(self, monkeypatch):
+        http_web._METADATA_REFRESH_TS.clear()
+        sdk = MagicMock()
+        monkeypatch.setattr(http_web, "_METADATA_REFRESH_INTERVAL_S", 0.0)
+        http_web._maybe_refresh_anime_metadata(sdk, 1)
+        time.sleep(0.01)
+        http_web._maybe_refresh_anime_metadata(sdk, 1)
+        assert sdk.refresh_anime_metadata.call_count == 2
+
+
+class TestAnimeInfoRows:
+    def test_builds_tags_and_date_rows(self):
+        anime = {
+            "title": "Bleach",
+            "title_synonyms": ["bleach", "BLEACH"],
+            "genres": ["Action"],
+            "date_from": 1_600_000_000,
+            "date_to": 1_700_000_000,
+        }
+        tags, alts, rows = http_web._anime_info_rows(
+            anime, user_state={}, terms=["1080p"]
+        )
+        assert tags == ["Action"]
+        assert alts == []
+        labels = [label for label, _ in rows]
+        assert "Start date" in labels
+        assert "Saved search terms" in labels
+
+
+class TestResolveGenreTags:
+    def test_resolves_numeric_ids_via_database(self, monkeypatch):
+        db = MagicMock()
+        db._fetch_genre_metadata_for_id.return_value = ["Romance", "Comedy"]
+        monkeypatch.setattr(http_web.Getters, "getDatabase", lambda _self=None: db)
+
+        assert http_web._resolve_genre_tags(10, ["5", "2"]) == ["Romance", "Comedy"]
+
+    def test_falls_back_to_genres_index_lookup(self, monkeypatch):
+        db = MagicMock()
+        db._fetch_genre_metadata_for_id.return_value = []
+        db.sql.return_value = [(5, "Romance"), (2, "Comedy")]
+        monkeypatch.setattr(http_web.Getters, "getDatabase", lambda _self=None: db)
+
+        assert http_web._resolve_genre_tags(10, ["5", "2"]) == ["Romance", "Comedy"]
+
+    def test_unknown_numeric_genre_uses_fallback(self, monkeypatch):
+        db = MagicMock()
+        db._fetch_genre_metadata_for_id.return_value = []
+        db.sql.return_value = []
+        monkeypatch.setattr(http_web.Getters, "getDatabase", lambda _self=None: db)
+
+        assert http_web._resolve_genre_tags(10, ["99"]) == [http_web._UNKNOWN_GENRE]
+
+
+class TestBuildAnimeDetailView:
+    def test_groups_airing_and_metadata_fields(self):
+        anime = {
+            "id": 7,
+            "title": "Sample",
+            "genres": ["Action"],
+            "date_from": 1_600_000_000,
+            "broadcast": "Tue 09:30",
+            "last_seen": "Episode 3",
+        }
+        view = http_web._build_anime_detail_view(
+            anime,
+            anime_id=7,
+            terms=["1080p"],
+            computed_status_text="Airing",
+            schedule_lines=[
+                "Since 07 Apr 2026 (41 days)",
+                "Next episode on Tue 19 at 09:30",
+                "Latest episode: 6 days ago",
+            ],
+        )
+
+        airing_labels = [field["label"] for field in view["airing_fields"]]
+        assert airing_labels[0] == "Status"
+        assert "Airs" in airing_labels
+        assert "Next episode" in airing_labels
+        assert "Latest episode" in airing_labels
+
+        airs = next(f for f in view["airing_fields"] if f["label"] == "Airs")
+        assert airs["value"] == "07 Apr 2026"
+        assert airs["hint"] == "41 days"
+
+        meta_labels = [field["label"] for field in view["metadata_fields"]]
+        assert "Start date" in meta_labels
+        assert "Broadcast" in meta_labels
+        assert "Saved search terms" in meta_labels
+        assert view["genre_tags"] == ["Action"]
+
+    def test_parse_schedule_line_labels(self):
+        row = http_web._parse_schedule_line("Next episode on Tue 19 at 09:30")
+        assert row["label"] == "Next episode"
+        assert "Tue 19" in row["value"]

--- a/tests/unit/clients/test_http_web_logs_pwa.py
+++ b/tests/unit/clients/test_http_web_logs_pwa.py
@@ -1,0 +1,140 @@
+"""Tests for log viewer routes and PWA assets in :mod:`clients.http.web`."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clients.http import log_buffer as lb
+
+http_app = importlib.import_module("clients.http.app")
+
+
+class _SettingsSDK:
+    def get_settings(self):
+        return {
+            "logs": {
+                "enabled_categories": list(lb.KNOWN_CATEGORIES),
+            }
+        }
+
+
+@pytest.fixture
+def log_client(monkeypatch):
+    """Isolated log buffer + minimal SDK for /ui/logs* routes."""
+    buf = lb.LogBuffer()
+    monkeypatch.setattr(lb, "global_buffer", buf)
+    monkeypatch.setattr(http_app, "get_sdk", lambda: _SettingsSDK())
+    with TestClient(http_app.app, follow_redirects=False) as client:
+        client.log_buffer = buf  # type: ignore[attr-defined]
+        yield client
+
+
+def _sample_record(message: str = "hello", *, category: str = "HTTP") -> dict:
+    return {
+        "levelno": logging.INFO,
+        "level": "INFO",
+        "logger": "tests.http",
+        "message": message,
+        "category": category,
+    }
+
+
+def test_logs_page_renders_snapshot(log_client):
+    log_client.log_buffer.add(_sample_record("boot line"))
+    resp = log_client.get("/ui/logs")
+    assert resp.status_code == 200
+    assert "boot line" in resp.text
+    assert "Logs" in resp.text
+
+
+def test_logs_page_category_chip_filter(log_client):
+    log_client.log_buffer.add(_sample_record("http only", category="HTTP"))
+    log_client.log_buffer.add(_sample_record("other only", category="OTHER"))
+    resp = log_client.get("/ui/logs", params={"category": "HTTP"})
+    assert resp.status_code == 200
+    assert "http only" in resp.text
+    assert "other only" not in resp.text
+
+
+def test_logs_data_json_since_and_limit(log_client):
+    log_client.log_buffer.add(_sample_record("first"))
+    log_client.log_buffer.add(_sample_record("second"))
+    snap = log_client.log_buffer.snapshot()
+    first_id = snap[0]["id"]
+    resp = log_client.get(
+        "/ui/logs/data",
+        params={"since": first_id, "limit": 10, "level": "INFO"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert len(payload["records"]) == 1
+    assert payload["records"][0]["message"] == "second"
+    assert payload["last_id"] == snap[-1]["id"]
+    assert payload["buffered"] >= 2
+
+
+def test_logs_data_text_and_logger_filters(log_client):
+    log_client.log_buffer.add(
+        {
+            **_sample_record("needle in haystack"),
+            "logger": "application.services.download_manager",
+            "module": "worker",
+        }
+    )
+    log_client.log_buffer.add(_sample_record("noise"))
+    resp = log_client.get(
+        "/ui/logs/data",
+        params={"q": "needle", "logger": "download"},
+    )
+    assert resp.status_code == 200
+    records = resp.json()["records"]
+    assert len(records) == 1
+    assert records[0]["message"] == "needle in haystack"
+
+
+def test_logs_clear_redirects(log_client):
+    log_client.log_buffer.add(_sample_record())
+    resp = log_client.post("/ui/logs/clear")
+    assert resp.status_code in {302, 303, 307}
+    assert resp.headers["location"].endswith("/ui/logs")
+    assert log_client.log_buffer.snapshot() == []
+
+
+def test_logs_clear_htmx_returns_empty_table(log_client):
+    log_client.log_buffer.add(_sample_record("gone"))
+    resp = log_client.post(
+        "/ui/logs/clear",
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    assert "gone" not in resp.text
+    assert "cleared" in resp.text.lower()
+
+
+def test_manifest_webmanifest(log_client):
+    resp = log_client.get("/ui/manifest.webmanifest")
+    assert resp.status_code == 200
+    assert "application/manifest+json" in resp.headers.get("content-type", "")
+    data = resp.json()
+    assert data["name"] == "AnimeManager"
+    assert data["start_url"] == "/ui/library"
+    assert data["scope"] == "/ui/"
+
+
+def test_service_worker_served(log_client):
+    resp = log_client.get("/ui/sw.js")
+    assert resp.status_code == 200
+    assert "javascript" in resp.headers.get("content-type", "")
+    assert resp.headers.get("Service-Worker-Allowed") == "/ui/"
+    assert "self" in resp.text or "addEventListener" in resp.text
+
+
+def test_offline_fallback_page(log_client):
+    resp = log_client.get("/ui/offline")
+    assert resp.status_code == 200
+    assert "offline" in resp.text.lower()

--- a/tests/unit/clients/test_http_web_ui.py
+++ b/tests/unit/clients/test_http_web_ui.py
@@ -78,6 +78,7 @@ class FakeSDK:
             "windows": {"mainWindowHeight": 500},
         }
         self._terms: dict[int, list[str]] = {1: ["SubsPlease 1080p"]}
+        self._last_torrent_queries: dict[int, str] = {}
         self._tags: dict[int, str] = {}
         self._likes: dict[int, bool] = {}
         self._playback_sessions: dict[str, dict] = {}
@@ -90,6 +91,48 @@ class FakeSDK:
 
     def _record(self, name: str, *args, **kwargs) -> None:
         self.calls.append((name, args, kwargs))
+
+    def _torrent_rows_for_terms(self, terms: list) -> list[dict]:
+        """Deterministic catalog slice; order is *not* seed-sorted yet."""
+        q = " ".join(str(t) for t in terms).lower()
+        if "youkoso" in q or "kyoushitsu" in q:
+            return [
+                {
+                    "name": "[OtherGroup] Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e - 01 (720p).mkv",
+                    "link": "magnet:?xt=urn:btih:classroom1",
+                    "size": 400_000_000,
+                    "seeds": 900,
+                    "leech": 2,
+                    "hash": "classroom1",
+                },
+                {
+                    "name": "[SubsPlease] Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e - 01 (1080p) [A1B2C3D4].mkv",
+                    "link": "magnet:?xt=urn:btih:classroom2",
+                    "size": 800_000_000,
+                    "seeds": 88,
+                    "leech": 4,
+                    "hash": "classroom2",
+                },
+            ]
+        # Lower-seed row first — callers must sort by seeds (matches production).
+        return [
+            {
+                "name": "[Erai-raws] Bleach S01 - 02 [720p].mkv",
+                "link": "magnet:?xt=urn:btih:def",
+                "size": 524288000,
+                "seeds": 7,
+                "leech": 1,
+                "hash": "def",
+            },
+            {
+                "name": "[SubsPlease] Bleach S01 - 01 [1080p].mkv",
+                "link": "magnet:?xt=urn:btih:abc",
+                "size": 1572864000,
+                "seeds": 42,
+                "leech": 3,
+                "hash": "abc",
+            },
+        ]
 
     # -- read paths ---------------------------------------------------------
     def get_anime_list(self, **kwargs):
@@ -126,8 +169,13 @@ class FakeSDK:
             "picture": "https://example.com/p.jpg",
             "status": "FINISHED",
             "synopsis": "A boy who can see ghosts.",
+            "title_synonyms": ["BLEACH", "Burichi"],
+            "date_from": 1094688000,
+            "date_to": 1398992400,
             "episodes": 366,
             "duration": 24,
+            "rating": "PG-13",
+            "broadcast": "SATURDAY 18:00",
             "genres": ["Action", "Shounen"],
             "trailer": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         }
@@ -140,6 +188,22 @@ class FakeSDK:
 
     def get_relations(self, anime_id: int, relation_type: str = "anime"):
         return [{"id": 9, "title": "Bleach: TYBW", "type": "sequel"}]
+
+    def get_anime_folder(self, anime_id: int):
+        self._record("get_anime_folder", anime_id)
+        return "C:/Anime/Bleach - 1"
+
+    def list_anime_characters(self, anime_id: int):
+        self._record("list_anime_characters", anime_id)
+        return [
+            {
+                "id": 101,
+                "name": "Ichigo Kurosaki",
+                "role": "main",
+                "picture": "https://example.com/c.jpg",
+                "synopsis": "Substitute Soul Reaper.",
+            }
+        ]
 
     def get_active_downloads(self):
         return [
@@ -154,39 +218,15 @@ class FakeSDK:
 
     def search_torrents(self, terms, profile="interactive", limit=200):
         self._record("search_torrents", terms, profile=profile, limit=limit)
-        return [
-            {
-                "name": "[SubsPlease] Bleach S01 - 01 [1080p].mkv",
-                "link": "magnet:?xt=urn:btih:abc",
-                "size": 1572864000,  # 1.5 GB
-                "seeds": 42,
-                "leech": 3,
-                "hash": "abc",
-            }
-        ]
+        rows = list(self._torrent_rows_for_terms(terms))
+        rows.sort(key=lambda row: int(row.get("seeds") or 0), reverse=True)
+        return rows[: max(1, limit)]
 
     def stream_torrents(self, terms, profile="interactive", limit=200):
-        """Yield results one-by-one so the streaming endpoint can exercise
-        the SSE row/end framing without a real subprocess pool."""
+        """Yield like production: seed-sorted within ``limit``."""
         self._record("stream_torrents", terms, profile=profile, limit=limit)
-        rows = [
-            {
-                "name": "[SubsPlease] Bleach S01 - 01 [1080p].mkv",
-                "link": "magnet:?xt=urn:btih:abc",
-                "size": 1572864000,
-                "seeds": 42,
-                "leech": 3,
-                "hash": "abc",
-            },
-            {
-                "name": "[Erai-raws] Bleach S01 - 02 [720p].mkv",
-                "link": "magnet:?xt=urn:btih:def",
-                "size": 524288000,
-                "seeds": 7,
-                "leech": 1,
-                "hash": "def",
-            },
-        ]
+        rows = list(self._torrent_rows_for_terms(terms))
+        rows.sort(key=lambda row: int(row.get("seeds") or 0), reverse=True)
         for row in rows[: max(1, limit)]:
             yield row
 
@@ -222,12 +262,40 @@ class FakeSDK:
             return True
         return False
 
+    def get_last_torrent_search_query(self, anime_id: int):
+        self._record("get_last_torrent_search_query", anime_id)
+        return self._last_torrent_queries.get(anime_id)
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str):
+        self._record("set_last_torrent_search_query", anime_id, query)
+        self._last_torrent_queries[anime_id] = query
+
+    def refresh_anime_metadata(self, anime_id: int):
+        self._record("refresh_anime_metadata", anime_id)
+        return self.get_anime(anime_id)
+
     def start_download(self, anime_id: int, url=None, hash_value=None, user_id=None):
         self._record("start_download", anime_id, url, hash_value, user_id)
         return True
 
     def cancel_download(self, anime_id: int):
         self._record("cancel_download", anime_id)
+        return True
+
+    def redownload(self, anime_id: int):
+        self._record("redownload", anime_id)
+        return 1
+
+    def delete_seen_episodes(self, anime_id: int, user_id: int):
+        self._record("delete_seen_episodes", anime_id, user_id)
+        return 1
+
+    def delete_all_files(self, anime_id: int, user_id: int):
+        self._record("delete_all_files", anime_id, user_id)
+        return 1
+
+    def delete_anime(self, anime_id: int):
+        self._record("delete_anime", anime_id)
         return True
 
     def get_anime_torrents(self, anime_id: int):
@@ -257,8 +325,36 @@ class FakeSDK:
                 "size_bytes": 1572864000,
                 "season": 1,
                 "episode": 1,
+                "duration_seconds": 100.0,
+                "position_seconds": 85.0,
+                "watch_status": "IN_PROGRESS",
             }
         ]
+
+    def set_episode_progress(
+        self,
+        anime_id: int,
+        user_id: int,
+        file_id: str,
+        status: str,
+        position_seconds=None,
+    ):
+        self._record(
+            "set_episode_progress",
+            anime_id,
+            user_id,
+            file_id,
+            status,
+            position_seconds,
+        )
+
+    def delete_episode_file(self, anime_id: int, file_id: str, user_id: int):
+        self._record("delete_episode_file", anime_id, file_id, user_id)
+        return True
+
+    def redownload_episode(self, anime_id: int, file_id: str, user_id: int):
+        self._record("redownload_episode", anime_id, file_id, user_id)
+        return True
 
     def create_playback_session(self, anime_id: int, file_id: str, **kwargs):
         self._record("create_playback_session", anime_id, file_id, kwargs)
@@ -377,16 +473,40 @@ def test_anime_detail_renders_actions_and_terms(client):
     assert resp.status_code == 200
     body = resp.text
     assert "A boy who can see ghosts" in body
+    assert "Alternative titles: Burichi" in body
+    assert "Start date" in body and "2004-09-09" in body
+    assert "End date" in body and "2014-05-02" in body
+    assert "Genres" in body
+    assert "Action" in body
+    assert "Status" in body
     assert "Torrent search options" in body
     assert "Search options" in body
     # Tag select + like form share the actions wrapper used as HTMX target
     assert 'id="anime-actions"' in body
     assert 'name="tag"' in body
     assert "/ui/anime/1/like" in body
-    # Search-term manager is no longer shown directly on this page.
-    assert 'id="search-terms"' not in body
+    assert "/ui/anime/1/characters" in body
+    assert 'id="search-terms"' in body
+    assert "Danger zone" in body
+    assert "Delete seen episodes" in body
+    assert "Remove from DB" in body
     # Relations table rendered
     assert "Bleach: TYBW" in body
+
+
+def test_anime_characters_page_renders(client):
+    resp = client.get("/ui/anime/1/characters")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Ichigo Kurosaki" in body
+    assert "Characters" in body
+    assert ("list_anime_characters", (1,), {}) in client.fake.calls
+
+
+def test_anime_characters_page_404(client):
+    resp = client.get("/ui/anime/404/characters")
+    assert resp.status_code == 404
+    assert "Not Found" in resp.text
 
 
 def test_anime_detail_404_renders_error_page(client):
@@ -531,8 +651,21 @@ def test_start_download_action(client):
         data={"url": "magnet:?xt=urn:btih:abc"},
     )
     assert resp.status_code == 303
-    assert resp.headers["location"].endswith("/ui/downloads")
+    assert resp.headers["location"].endswith("/ui/anime/1")
     assert ("start_download", (1, "magnet:?xt=urn:btih:abc", None, 1), {}) in client.fake.calls
+
+
+def test_start_download_action_respects_referer(client):
+    resp = client.post(
+        "/ui/anime/1/download",
+        data={"url": "magnet:?xt=urn:btih:abc"},
+        headers={"Referer": "http://testserver/ui/torrents?anime_id=1&term=foo"},
+    )
+    assert resp.status_code == 303
+    loc = resp.headers["location"]
+    assert "/ui/torrents" in loc
+    assert "anime_id=1" in loc
+    assert "term=foo" in loc
 
 
 def test_cancel_download_action(client):
@@ -548,6 +681,29 @@ def test_torrents_search_renders_results(client):
     assert "[SubsPlease] Bleach S01" in body
     assert "1.5 GB" in body  # humanized size
     assert "42" in body  # seeds badge
+    lo = body.lower()
+    assert lo.find("[subsplease] bleach s01") < lo.find("[erai-raws]")
+
+
+def test_torrents_search_youkoso_jitsuryoku_includes_subsplease_high_seeds_first(client):
+    """Regression: long-title anime search surfaces SubsPlease, ordered by seeds."""
+    term = "Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e"
+    resp = client.get("/ui/torrents", params={"term": term})
+    assert resp.status_code == 200
+    body = resp.text
+    assert "subsplease" in body.lower()
+    assert "[SubsPlease] Youkoso Jitsuryoku" in body
+    lo = body.lower()
+    assert lo.find("[othergroup]") < lo.find("[subsplease] youkoso")
+
+    stream = client.get(
+        "/ui/anime/1/torrents/stream",
+        params={"term": term},
+    )
+    assert stream.status_code == 200
+    slo = stream.text.lower()
+    assert "subsplease" in slo
+    assert slo.find("[othergroup]") < slo.find("[subsplease] youkoso")
 
 
 def test_torrents_search_empty_state(client):
@@ -774,9 +930,15 @@ def test_static_assets_served(client):
     css = client.get("/ui/static/css/app.css")
     assert css.status_code == 200
     assert "Anime" in css.text  # header comment present
+    assert ".watch-view__video-wrap:fullscreen" in css.text
+    assert "overflow: visible;" in css.text
     js = client.get("/ui/static/js/app.js")
     assert js.status_code == 200
     assert "AnimeManager web UI helpers" in js.text
+    assert "resolveFullscreenTarget" in js.text
+    subtitles_js = client.get("/ui/static/js/am_playback_subtitles.js")
+    assert subtitles_js.status_code == 200
+    assert "refreshOctopusLayout" in subtitles_js.text
 
 
 # ---------------------------------------------------------------------------
@@ -1027,15 +1189,86 @@ def test_seen_action_returns_partial_for_htmx(client):
     assert 'id="anime-actions"' in resp.text
 
 
-def test_cancel_download_redirects_to_downloads_page(client):
+def test_refresh_metadata_action_redirects(client):
+    resp = client.post("/ui/anime/1/refresh")
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/ui/anime/1")
+    assert ("refresh_anime_metadata", (1,), {}) in client.fake.calls
+
+
+def test_redownload_action_redirects(client):
+    resp = client.post("/ui/anime/1/redownload")
+    assert resp.status_code == 303
+    assert ("redownload", (1,), {}) in client.fake.calls
+
+
+def test_delete_seen_episodes_action_redirects(client):
+    resp = client.post("/ui/anime/1/delete-seen")
+    assert resp.status_code == 303
+    assert ("delete_seen_episodes", (1, 1), {}) in client.fake.calls
+
+
+def test_delete_all_files_action_redirects(client):
+    resp = client.post("/ui/anime/1/delete-files")
+    assert resp.status_code == 303
+    assert ("delete_all_files", (1, 1), {}) in client.fake.calls
+
+
+def test_remove_anime_action_redirects_to_library(client):
+    resp = client.post("/ui/anime/1/remove")
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/ui/library")
+    assert ("delete_anime", (1,), {}) in client.fake.calls
+
+
+def test_episode_progress_redirects_when_plain_form_post(client):
+    """Vanilla form POST (no HTMX) uses PRG redirect to the anime page."""
+    resp = client.post(
+        "/ui/anime/1/episode-progress",
+        data={
+            "file_id": "f1",
+            "status": "IN_PROGRESS",
+            "position_seconds": "12.5",
+        },
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/ui/anime/1")
+
+
+def test_episode_progress_no_content_for_player_background_fetch(client):
+    """In-player ``fetch`` must not 303 to a full-page GET (breaks streaming)."""
+    resp = client.post(
+        "/ui/anime/1/episode-progress",
+        data={
+            "file_id": "f1",
+            "status": "IN_PROGRESS",
+            "position_seconds": "30",
+        },
+        headers={"X-AM-Player-Background": "true"},
+    )
+    assert resp.status_code == 204
+    assert not resp.content
+
+
+def test_episode_progress_returns_partial_for_htmx(client):
+    resp = client.post(
+        "/ui/anime/1/episode-progress",
+        data={"file_id": "f1", "status": "SEEN", "position_seconds": "0"},
+        headers={"hx-request": "true"},
+    )
+    assert resp.status_code == 200
+    assert 'id="anime-player"' in resp.text
+
+
+def test_cancel_download_redirects_to_anime_without_referer(client):
     resp = client.post("/ui/anime/1/cancel")
     assert resp.status_code == 303
-    assert resp.headers["location"].endswith("/ui/downloads")
+    assert resp.headers["location"].endswith("/ui/anime/1")
 
 
 def test_start_download_validates_missing_url(client):
     """Without url or hash_value the SDK should raise; route swallows
-    the error and still redirects (UX: PRG always lands on /downloads)."""
+    the error and still redirects (PRG lands on anime page when no Referer)."""
     from domain.errors import ValidationError
 
     def boom(*_args, **_kwargs):
@@ -1044,7 +1277,7 @@ def test_start_download_validates_missing_url(client):
     client.fake.start_download = boom  # type: ignore[assignment]
     resp = client.post("/ui/anime/1/download")
     assert resp.status_code == 303
-    assert resp.headers["location"].endswith("/ui/downloads")
+    assert resp.headers["location"].endswith("/ui/anime/1")
 
 
 # ---------------------------------------------------------------------------
@@ -1117,6 +1350,15 @@ def test_anime_torrent_search_partial_uses_saved_terms_by_default(client):
     assert not any(c[0] in {"search_torrents", "stream_torrents"} for c in client.fake.calls)
 
 
+def test_anime_torrent_search_partial_prefers_last_search_over_saved_terms(client):
+    client.fake._last_torrent_queries[1] = "HorribleSubs 720p"
+    resp = client.get("/ui/anime/1/torrents")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "HorribleSubs 720p" in body
+    assert "last search" in body.lower()
+
+
 def test_anime_torrent_search_partial_honors_override_term(client):
     resp = client.get(
         "/ui/anime/1/torrents",
@@ -1127,6 +1369,25 @@ def test_anime_torrent_search_partial_honors_override_term(client):
     assert "horriblesubs 720p" in body
     # The stream URL carries the override term verbatim.
     assert "term=horriblesubs%20720p" in body or "term=horriblesubs+720p" in body
+
+
+def test_anime_torrent_stream_fans_out_title_synonyms_when_no_saved_terms(
+    client, monkeypatch
+):
+    monkeypatch.setattr(client.fake, "get_search_terms", lambda anime_id: [])
+    monkeypatch.setattr(
+        client.fake,
+        "get_anime",
+        lambda anime_id: {
+            "id": anime_id,
+            "title": "Main Title",
+            "title_synonyms": ["MAIN TITLE", "Alt One"],
+        },
+    )
+    resp = client.get("/ui/anime/42/torrents/stream")
+    assert resp.status_code == 200
+    last = [c for c in client.fake.calls if c[0] == "stream_torrents"][-1]
+    assert last[1][0] == ["Main Title", "Alt One"]
 
 
 def test_anime_torrent_stream_returns_sse_rows(client):
@@ -1141,11 +1402,14 @@ def test_anime_torrent_stream_returns_sse_rows(client):
     assert body.count("event: row") == 2
     assert "[SubsPlease] Bleach S01 - 01 [1080p].mkv" in body
     assert "[Erai-raws] Bleach S01 - 02" in body
+    blo = body.lower()
+    assert blo.find("subsplease") < blo.find("erai-raws")
     # The stream completes with a final end event carrying the row count
     assert "event: end" in body
     # And the SDK was asked to stream (not the materialized variant)
     last_call = [c for c in client.fake.calls if c[0] == "stream_torrents"][-1]
     assert last_call[1][0] == ["bleach 1080p"]
+    assert ("set_last_torrent_search_query", (1, "bleach 1080p"), {}) in client.fake.calls
 
 
 def test_anime_torrent_stream_emits_error_event_when_no_term(client, monkeypatch):
@@ -1163,6 +1427,7 @@ def test_anime_torrent_stream_emits_error_event_when_no_term(client, monkeypatch
 
 
 def test_anime_detail_page_wires_inline_torrent_search(client):
+    client.fake._last_torrent_queries[1] = "previously used query"
     resp = client.get("/ui/anime/1")
     assert resp.status_code == 200
     body = resp.text
@@ -1173,43 +1438,120 @@ def test_anime_detail_page_wires_inline_torrent_search(client):
     assert 'hx-target="#anime-torrent-results"' in body
     # The HTMX form auto-loads results on page open
     assert 'hx-trigger="load"' in body
+    assert 'value="previously used query"' in body
 
 
 # ---------------------------------------------------------------------------
-# Downloaded episodes section
+# Episodes & downloads section (merged local player + torrent list)
 # ---------------------------------------------------------------------------
 
 
-def test_anime_detail_downloaded_episodes_lists_saved_torrents(client):
+def test_anime_detail_episodes_and_downloads_lists_saved_torrents(client):
     resp = client.get("/ui/anime/1")
     assert resp.status_code == 200
     body = resp.text
-    assert "Downloaded episodes" in body
-    # Saved torrent name from FakeSDK.get_anime_torrents
-    assert "[SubsPlease] Bleach S01 - 02 [1080p].mkv" in body
-    # Active downloads with the same anime_id are merged in
-    assert "[SubsPlease] Bleach - 01.mkv" in body
-    # FakeSDK.get_anime_torrents reports a complete download (size == downloaded)
-    assert "COMPLETE" in body
-    # Active download from FakeSDK.get_active_downloads is in DOWNLOADING state
-    assert "DOWNLOADING" in body
+    assert "episodes-panel" in body
+    panel = client.get("/ui/anime/1/episodes-panel")
+    assert panel.status_code == 200
+    frag = panel.text
+    assert "Episodes &amp; downloads" in frag
+    assert "[SubsPlease] Bleach S01 - 02 [1080p].mkv" in frag
+    assert "[SubsPlease] Bleach - 01.mkv" in frag
+    assert "COMPLETE" in frag
+    assert "DOWNLOADING" in frag
 
 
-def test_anime_detail_downloaded_episodes_empty_when_none(client, monkeypatch):
+def test_anime_detail_episodes_and_downloads_empty_when_none(client, monkeypatch):
     monkeypatch.setattr(client.fake, "get_anime_torrents", lambda anime_id: [])
     monkeypatch.setattr(client.fake, "get_active_downloads", lambda: [])
+    monkeypatch.setattr(
+        client.fake,
+        "list_episode_files",
+        lambda anime_id, user_id=None: [],
+    )
     resp = client.get("/ui/anime/1")
     assert resp.status_code == 200
-    assert "Nothing downloaded yet" in resp.text
+    panel = client.get("/ui/anime/1/episodes-panel")
+    assert panel.status_code == 200
+    assert "Nothing here yet" in panel.text
 
 
 def test_anime_detail_renders_episode_player_links(client):
     resp = client.get("/ui/anime/1")
     assert resp.status_code == 200
+    assert "episodes-panel" in resp.text
+    panel = client.get("/ui/anime/1/episodes-panel")
+    assert panel.status_code == 200
+    frag = panel.text
+    assert "Episodes &amp; downloads" in frag
+    assert "/ui/anime/1/watch?file_id=ep-001" in frag
+    assert "data-episode-menu" in frag
+    assert "progress--watch" in frag
+    assert "progress--watch-high" in frag
+
+
+def test_anime_detail_omits_removed_action_controls(client):
+    resp = client.get("/ui/anime/1")
     body = resp.text
-    assert "Episode player" in body
-    assert "Open player" in body or "watch?file_id=ep-001" in body
-    assert "/ui/anime/1/watch?file_id=ep-001" in body
+    assert "Refresh metadata" not in body
+    assert "Open folder" not in body
+    assert "Save seen" not in body
+    assert 'name="file_name"' not in body
+
+
+def test_anime_detail_auto_refresh_metadata_throttled(client):
+    http_web._METADATA_REFRESH_TS.clear()
+    client.fake.calls.clear()
+    client.get("/ui/anime/1")
+    first = sum(1 for c in client.fake.calls if c[0] == "refresh_anime_metadata")
+    assert first == 1
+    client.get("/ui/anime/1")
+    second = sum(1 for c in client.fake.calls if c[0] == "refresh_anime_metadata")
+    assert second == first
+
+
+def test_episodes_panel_omits_aggregate_progress_and_has_row_menu(client):
+    panel = client.get("/ui/anime/1/episodes-panel")
+    frag = panel.text
+    assert "Overall download progress" not in frag
+    assert "data-episode-menu" in frag
+    assert "Mark seen" in frag
+    assert "Mark unseen" in frag
+    assert "/ui/anime/1/episode-redownload" in frag
+
+
+def test_episode_mark_seen_htmx_updates_panel(client):
+    resp = client.post(
+        "/ui/anime/1/episode-mark-seen",
+        data={"file_id": "ep-001"},
+        headers={"hx-request": "true"},
+    )
+    assert resp.status_code == 200
+    assert ("set_episode_progress", (1, 1, "ep-001", "SEEN", None), {}) in client.fake.calls
+
+
+def test_episode_mark_unseen_htmx_updates_panel(client):
+    resp = client.post(
+        "/ui/anime/1/episode-mark-unseen",
+        data={"file_id": "ep-001"},
+        headers={"hx-request": "true"},
+    )
+    assert resp.status_code == 200
+    assert (
+        "set_episode_progress",
+        (1, 1, "ep-001", "UNSEEN", 0.0),
+        {},
+    ) in client.fake.calls
+
+
+def test_episode_redownload_htmx_updates_panel(client):
+    resp = client.post(
+        "/ui/anime/1/episode-redownload",
+        data={"file_id": "ep-001"},
+        headers={"hx-request": "true"},
+    )
+    assert resp.status_code == 200
+    assert ("redownload_episode", (1, "ep-001", 1), {}) in client.fake.calls
 
 
 def test_playback_session_create_returns_manifest_payload(client):
@@ -1231,6 +1573,10 @@ def test_watch_page_renders_player_view(client):
     # user interaction with the media-chrome controls.
     assert "data-player-auto-fullscreen=\"0\"" in body
     assert "data-player-auto-fullscreen=\"1\"" not in body
+    # Fullscreen host keeps video and ASS overlay in the same subtree.
+    assert 'id="watch-wrap-1"' in body
+    assert 'fullscreenelement="watch-wrap-1"' in body
+    assert "data-player-ass-overlay" in body
 
 
 def test_stream_manifest_requires_token(client):
@@ -1259,4 +1605,4 @@ def test_stream_heartbeat_and_stop_endpoints(client):
     assert hb.status_code == 200
     stop = client.post("/ui/stream/sess-1/stop")
     assert stop.status_code == 200
-    
+    assert stop.json()["ok"] is True

--- a/tests/unit/clients/test_sdk_contract.py
+++ b/tests/unit/clients/test_sdk_contract.py
@@ -83,6 +83,13 @@ class FakeFacade:
         _ = (anime_id, term)
         return True
 
+    def get_last_torrent_search_query(self, anime_id: int):
+        _ = anime_id
+        return None
+
+    def set_last_torrent_search_query(self, anime_id: int, query: str):
+        _ = (anime_id, query)
+
     def get_settings(self):
         return self.settings
 
@@ -93,6 +100,10 @@ class FakeFacade:
     def get_relations(self, anime_id: int, relation_type: str = "anime"):
         _ = (anime_id, relation_type)
         return [{"id": anime_id, "name": "SEQUEL", "rel_id": 2}]
+
+    def list_anime_characters(self, anime_id: int):
+        _ = anime_id
+        return [{"id": 7, "name": "Side", "role": "supporting"}]
 
 
 def test_sdk_extended_contract(monkeypatch):
@@ -109,3 +120,4 @@ def test_sdk_extended_contract(monkeypatch):
     assert sdk.get_settings()["anime"]["hideRated"] is True
     assert sdk.update_settings({"anime": {"hideRated": False}})["anime"]["hideRated"] is False
     assert sdk.get_relations(1)[0]["name"] == "SEQUEL"
+    assert sdk.list_anime_characters(3)[0]["name"] == "Side"

--- a/tests/unit/clients/test_sdk_edges.py
+++ b/tests/unit/clients/test_sdk_edges.py
@@ -32,6 +32,16 @@ class FakeFacade:
     def get_anime_details(self, anime_id):
         return AnimeEntity(id=anime_id, title="Detail")
 
+    def refresh_anime_metadata(self, anime_id):
+        return AnimeEntity(id=anime_id, title="Refreshed")
+
+    def delete_anime(self, anime_id):
+        self.calls.append(("delete_anime", anime_id))
+        return True
+
+    def get_anime_folder(self, anime_id):
+        return f"/anime/{anime_id}"
+
     def start_download(self, anime_id, url=None, hash_value=None, user_id=None):
         return True
 
@@ -40,6 +50,10 @@ class FakeFacade:
 
     def cancel_download(self, anime_id):
         return True
+
+    def redownload(self, anime_id):
+        self.calls.append(("redownload", anime_id))
+        return 1
 
     def get_active_downloads(self):
         return [{"anime_id": 1}]
@@ -68,6 +82,12 @@ class FakeFacade:
     def remove_search_term(self, anime_id, term):
         return True
 
+    def get_last_torrent_search_query(self, anime_id):
+        return None
+
+    def set_last_torrent_search_query(self, anime_id, query):
+        pass
+
     def get_settings(self):
         return {"anime": {"hideRated": True}}
 
@@ -76,6 +96,18 @@ class FakeFacade:
 
     def get_relations(self, anime_id, relation_type="anime"):
         return [{"id": 1, "rel_id": 2}]
+
+    def list_anime_characters(self, anime_id):
+        self.calls.append(("list_anime_characters", anime_id))
+        return [{"id": 9, "name": "Mugiwara"}]
+
+    def delete_all_files(self, anime_id, user_id):
+        self.calls.append(("delete_all_files", anime_id, user_id))
+        return 2
+
+    def delete_seen_episodes(self, anime_id, user_id):
+        self.calls.append(("delete_seen_episodes", anime_id, user_id))
+        return 1
 
 
 @pytest.fixture
@@ -122,8 +154,21 @@ class TestSDKEdges:
         out = sdk.get_anime(42)
         assert out["id"] == 42
 
+    def test_refresh_anime_metadata_returns_dict(self, sdk):
+        out = sdk.refresh_anime_metadata(42)
+        assert out["title"] == "Refreshed"
+
+    def test_delete_anime_returns_bool(self, sdk):
+        assert sdk.delete_anime(42) is True
+
+    def test_get_anime_folder(self, sdk):
+        assert sdk.get_anime_folder(2) == "/anime/2"
+
     def test_start_download_pass_through(self, sdk):
         assert sdk.start_download(1, url="magnet:?xt=urn:btih:abc") is True
+
+    def test_redownload_pass_through(self, sdk):
+        assert sdk.redownload(1) == 1
 
     def test_get_download_progress_returns_dict(self, sdk):
         assert sdk.get_download_progress(1) == {"anime_id": 1, "progress": 30}
@@ -150,6 +195,12 @@ class TestSDKEdges:
         sdk.mark_seen(1, "ep.mkv", 7)
         assert ("mark_seen", 1, "ep.mkv", 7) in sdk._facade.calls
 
+    def test_delete_all_files(self, sdk):
+        assert sdk.delete_all_files(1, 7) == 2
+
+    def test_delete_seen_episodes(self, sdk):
+        assert sdk.delete_seen_episodes(1, 7) == 1
+
     def test_update_settings_returns_dict(self, sdk):
         out = sdk.update_settings({"a": 1})
         assert out == {"a": 1}
@@ -157,6 +208,11 @@ class TestSDKEdges:
     def test_get_relations_default_anime_type(self, sdk):
         out = sdk.get_relations(1)
         assert out == [{"id": 1, "rel_id": 2}]
+
+    def test_list_anime_characters(self, sdk):
+        out = sdk.list_anime_characters(2)
+        assert out == [{"id": 9, "name": "Mugiwara"}]
+        assert ("list_anime_characters", 2) in sdk._facade.calls
 
     def test_get_search_terms_returns_list(self, sdk):
         assert sdk.get_search_terms(1) == ["x"]

--- a/tests/unit/composition/test_facade_edges.py
+++ b/tests/unit/composition/test_facade_edges.py
@@ -147,6 +147,17 @@ def test_remove_search_term_forwards(facade, service):
     assert facade.remove_search_term(1, "t") is True
 
 
+def test_get_last_torrent_search_query_forwards(facade, service):
+    service.get_last_torrent_search_query.return_value = "a, b"
+    assert facade.get_last_torrent_search_query(3) == "a, b"
+    service.get_last_torrent_search_query.assert_called_once_with(3)
+
+
+def test_set_last_torrent_search_query_forwards(facade, service):
+    facade.set_last_torrent_search_query(2, "x, y")
+    service.set_last_torrent_search_query.assert_called_once_with(2, "x, y")
+
+
 def test_get_settings_returns_dict(facade, service):
     service.get_settings.return_value = {"x": 1}
     assert facade.get_settings() == {"x": 1}
@@ -168,7 +179,135 @@ def test_get_relations_custom_type(facade, service):
     service.get_relations.assert_called_once_with(1, "manga")
 
 
+def test_list_anime_characters_forwards(facade, service):
+    service.list_anime_characters.return_value = [{"id": 1, "name": "A"}]
+    assert facade.list_anime_characters(5) == [{"id": 1, "name": "A"}]
+    service.list_anime_characters.assert_called_once_with(5)
+
+
 def test_service_errors_propagate(facade, service):
     service.get_anime_details.side_effect = RuntimeError("boom")
     with pytest.raises(RuntimeError):
         facade.get_anime_details(1)
+
+
+def test_stream_search_anime_uses_streamer_when_present(facade, service):
+    def _stream(req):
+        yield f"item-{req.query}"
+
+    service.stream_search_anime = _stream
+    assert list(facade.stream_search_anime("abc", limit=3)) == ["item-abc"]
+    service.search_anime.assert_not_called()
+
+
+def test_stream_search_anime_falls_back_to_search(facade, service):
+    del service.stream_search_anime
+    service.search_anime.return_value = ["x", "y"]
+    assert list(facade.stream_search_anime("q", limit=5)) == ["x", "y"]
+    service.search_anime.assert_called_once_with(SearchRequest(query="q", limit=5))
+
+
+def test_startup_jobs_property_and_run(facade, service):
+    jobs = MagicMock()
+    report = MagicMock()
+    jobs.run.return_value = report
+    facade_with_jobs = EmbeddedClientFacade(service, startup_jobs=jobs)
+    assert facade_with_jobs.startup_jobs is jobs
+    assert facade_with_jobs.run_startup_jobs() is report
+    jobs.run.assert_called_once()
+
+
+def test_startup_jobs_absent_returns_none(facade):
+    assert facade.startup_jobs is None
+    assert facade.run_startup_jobs() is None
+    assert facade.kickoff_startup_jobs() is None
+
+
+def test_kickoff_startup_jobs_returns_thread(facade, service):
+    jobs = MagicMock()
+    thread = MagicMock()
+    jobs.run_in_background.return_value = thread
+    out = EmbeddedClientFacade(service, startup_jobs=jobs).kickoff_startup_jobs()
+    assert out is thread
+    jobs.run_in_background.assert_called_once()
+
+
+def test_refresh_delete_folder_and_redownload(facade, service):
+    facade.refresh_anime_metadata(9)
+    service.refresh_anime_metadata.assert_called_once_with(9)
+    service.delete_anime.return_value = True
+    assert facade.delete_anime(9) is True
+    service.get_anime_folder.return_value = "/anime/9"
+    assert facade.get_anime_folder(9) == "/anime/9"
+    service.redownload.return_value = 2
+    assert facade.redownload(9) == 2
+
+
+def test_torrent_overview_and_stream(facade, service):
+    service.get_torrents_overview.return_value = {"active": []}
+    assert facade.get_torrents_overview() == {"active": []}
+    service.stream_torrents.return_value = iter([{"name": "t"}])
+    assert list(facade.stream_torrents(["a"], profile="p", limit=10)) == [{"name": "t"}]
+    service.stream_torrents.assert_called_once_with(["a"], profile="p", limit=10)
+
+
+def test_get_anime_torrents_and_episode_files(facade, service):
+    service.get_anime_torrents.return_value = [{"hash": "h"}]
+    assert facade.get_anime_torrents(4) == [{"hash": "h"}]
+    service.list_episode_files.return_value = [{"file_id": "ep-1"}]
+    assert facade.list_episode_files(4, user_id=7) == [{"file_id": "ep-1"}]
+    service.list_episode_files.assert_called_once_with(4, user_id=7)
+
+
+def test_episode_progress_and_deletes(facade, service):
+    facade.set_episode_progress(1, 2, "ep-1", "seen", position_seconds=12.5)
+    service.set_episode_progress.assert_called_once_with(
+        1, 2, "ep-1", "seen", position_seconds=12.5
+    )
+    service.delete_episode_file.return_value = True
+    assert facade.delete_episode_file(1, "ep-1", 2) is True
+    service.redownload_episode.return_value = True
+    assert facade.redownload_episode(1, "ep-1", 2) is True
+    service.redownload_episode.assert_called_once_with(1, "ep-1", 2)
+    service.delete_all_files.return_value = 3
+    assert facade.delete_all_files(1, 2) == 3
+    service.delete_seen_episodes.return_value = 1
+    assert facade.delete_seen_episodes(1, 2) == 1
+
+
+def test_playback_session_methods(facade, service):
+    session = {"session_id": "s1"}
+    service.create_playback_session.return_value = session
+    out = facade.create_playback_session(
+        1,
+        "ep-1",
+        client_host="127.0.0.1",
+        ttl_seconds=60,
+        audio_track=0,
+        subtitle_track=1,
+        start_time_seconds=5.0,
+    )
+    assert out is session
+    service.create_playback_session.assert_called_once_with(
+        anime_id=1,
+        file_id="ep-1",
+        client_host="127.0.0.1",
+        ttl_seconds=60,
+        audio_track=0,
+        subtitle_track=1,
+        start_time_seconds=5.0,
+    )
+    service.heartbeat_playback_session.return_value = {"ok": True}
+    assert facade.heartbeat_playback_session("s1") == {"ok": True}
+    facade.stop_playback_session("s1")
+    service.stop_playback_session.assert_called_once_with("s1")
+    service.resolve_playback_media_path.return_value = "/tmp/seg.ts"
+    assert (
+        facade.resolve_playback_media_path(
+            session_id="s1", token="tok", segment_name="seg.ts"
+        )
+        == "/tmp/seg.ts"
+    )
+    service.resolve_playback_media_path.assert_called_once_with(
+        session_id="s1", token="tok", segment_name="seg.ts"
+    )

--- a/tests/unit/search_engines/test_ranking_shim.py
+++ b/tests/unit/search_engines/test_ranking_shim.py
@@ -1,0 +1,15 @@
+"""Tests for the ``search_engines.ranking`` compatibility shim."""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+def test_ranking_shim_warns_on_reload():
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always", category=DeprecationWarning)
+        import search_engines.ranking as ranking_mod
+
+        importlib.reload(ranking_mod)
+    assert any("compatibility shim" in str(w.message) for w in recorded)
+    assert any(issubclass(w.category, DeprecationWarning) for w in recorded)

--- a/tests/unit/shared/test_getters_edges.py
+++ b/tests/unit/shared/test_getters_edges.py
@@ -1,0 +1,340 @@
+"""Edge case tests for ``shared.config.getters`` (LRU cache, decorators, helpers)."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.legacy.legacy_classes import Anime, Torrent
+from shared.config.getters import LRUCache, Getters, cached_getter
+
+
+# ---------------------------------------------------------------------------
+# LRUCache
+# ---------------------------------------------------------------------------
+
+
+class TestLRUCache:
+    def test_get_set_roundtrip(self):
+        cache = LRUCache(max_size=10, ttl=300)
+        cache.set("k", "v")
+        assert cache.get("k") == "v"
+
+    def test_get_missing_returns_none(self):
+        assert LRUCache().get("missing") is None
+
+    def test_expired_entry_returns_none(self):
+        cache = LRUCache(max_size=10, ttl=1)
+        cache.set("k", "v")
+        with patch("shared.config.getters.time.time", return_value=time.time() + 2):
+            assert cache.get("k") is None
+
+    def test_evicts_oldest_when_at_capacity(self):
+        cache = LRUCache(max_size=2, ttl=300)
+        cache.set("a", 1)
+        time.sleep(0.01)
+        cache.set("b", 2)
+        cache.set("c", 3)  # should evict "a"
+        assert cache.get("a") is None
+        assert cache.get("b") == 2
+        assert cache.get("c") == 3
+
+    def test_clear_removes_all(self):
+        cache = LRUCache()
+        cache.set("x", 1)
+        cache.clear()
+        assert cache.get("x") is None
+
+    def test_evict_oldest_on_empty_access_times(self):
+        cache = LRUCache()
+        cache._evict_oldest()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# cached_getter decorator
+# ---------------------------------------------------------------------------
+
+
+class _CachedHost:
+    def __init__(self):
+        self.counter = 0
+
+    def log(self, category: str, message: str, *args) -> None:
+        pass
+
+    @cached_getter(ttl=300, max_size=10)
+    def compute(self, n: int):
+        self.counter += 1
+        return n * 2
+
+
+class TestCachedGetter:
+    def test_caches_return_value(self):
+        host = _CachedHost()
+        assert host.compute(3) == 6
+        assert host.compute(3) == 6
+        assert host.counter == 1
+
+    def test_does_not_cache_none(self):
+        class _NoneHost:
+            def log(self, *a, **k):
+                pass
+
+            @cached_getter()
+            def sometimes_none(self, flag: bool):
+                return None if flag else "ok"
+
+        host = _NoneHost()
+        assert host.sometimes_none(True) is None
+        assert host.sometimes_none(True) is None  # not cached; would differ if cached
+
+    def test_unhashable_kwargs_use_string_fallback(self):
+        class _UnhashableHost:
+            def __init__(self):
+                self.logged = False
+
+            def log(self, *a, **k):
+                self.logged = True
+
+            @cached_getter()
+            def compute(self, n, extras=None):
+                return n + len(extras or [])
+
+        host = _UnhashableHost()
+        payload = [1, 2]
+        assert host.compute(1, extras=payload) == 3
+        assert host.compute(1, extras=payload) == 3
+        assert host.logged is True
+
+
+# ---------------------------------------------------------------------------
+# Static helpers (additional branches)
+# ---------------------------------------------------------------------------
+
+
+class TestGettersStaticEdges:
+    def test_getStatus_single_episode_finished(self):
+        anime = Anime(
+            {
+                "status": None,
+                "date_from": 1554508800,
+                "date_to": None,
+                "episodes": 1,
+            }
+        )
+        assert Getters.getStatus(anime) == "FINISHED"
+
+    def test_getStatus_airing_with_future_end_date(self):
+        future = int((datetime.now(timezone.utc).timestamp()) + 86400 * 365)
+        anime = Anime(
+            {
+                "status": None,
+                "date_from": 1554508800,
+                "date_to": future,
+                "episodes": 12,
+            }
+        )
+        assert Getters.getStatus(anime) == "AIRING"
+
+    def test_getMagnetHash_base32_decodes_to_hex(self):
+        import base64
+
+        raw = b"\xab" * 20
+        b32 = base64.b32encode(raw).decode().rstrip("=")
+        url = f"magnet:?xt=urn:btih:{b32}"
+        result = Getters.getMagnetHash(url)
+        assert len(result) == 40
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_getFolderFormat_hyphen_becomes_space(self):
+        assert Getters.getFolderFormat("Naruto-Shippuden") == "Naruto Shippuden"
+
+
+class TestGetFeatureFlagEdges:
+    def test_returns_default_when_settings_not_dict(self):
+        host = SimpleNamespace(settings="bad")
+        assert Getters.getFeatureFlag(host, "x", default=True) is True
+
+    def test_returns_default_when_flags_not_dict(self):
+        host = SimpleNamespace(settings={"feature_flags": []})
+        assert Getters.getFeatureFlag(host, "x", default=False) is False
+
+    def test_string_false_values(self):
+        host = SimpleNamespace(
+            settings={"feature_flags": {"off": "no", "on": "yes"}}
+        )
+        assert Getters.getFeatureFlag(host, "off") is False
+        assert Getters.getFeatureFlag(host, "on") is True
+
+
+class TestGetDatabaseEdges:
+    def test_raises_when_manager_missing(self):
+        host = MagicMock(spec=Getters)
+        host.settings = {"database_managers": {"last_db_used": "missing"}}
+        with patch("shared.config.getters.db_managers") as mock_db:
+            mock_db.databases = {}
+            with pytest.raises(ModuleNotFoundError, match="missing"):
+                Getters.getDatabase(host)
+
+    def test_reuses_cached_instance_for_same_args(self):
+        host = MagicMock(spec=Getters)
+        host.settings = {
+            "database_managers": {
+                "last_db_used": "sqlite",
+                "sqlite": {"path": ":memory:"},
+            }
+        }
+        import shared.config.getters as getters_mod
+
+        getters_mod._database_instances.clear()
+        try:
+            with patch("shared.config.getters.db_managers") as mock_db:
+                mock_cls = MagicMock()
+                mock_instance = MagicMock()
+                mock_cls.return_value = mock_instance
+                mock_db.databases = {"sqlite": mock_cls}
+
+                first = Getters.getDatabase(host)
+                second = Getters.getDatabase(host)
+
+                assert first is second
+                mock_cls.assert_called_once()
+        finally:
+            getters_mod._database_instances.clear()
+
+
+class TestGetEpisodes:
+    def _make_host(self, fm):
+        host = MagicMock(spec=Getters)
+        host.fm = fm
+        return host
+
+    def test_empty_folder_returns_empty_list(self):
+        fm = MagicMock()
+        fm.exists.return_value = False
+        assert Getters.getEpisodes(self._make_host(fm), "") == []
+
+    def test_parses_episode_and_season_from_filenames(self):
+        fm = MagicMock()
+        fm.exists.return_value = True
+        fm.isdir.return_value = False
+        fm.isfile.return_value = True
+        fm.list.return_value = [
+            "[Group] Show - 01.mkv",
+            "[Group] Show S02 Ep03.mkv",
+        ]
+
+        result = Getters.getEpisodes(self._make_host(fm), "/anime/Show - 1")
+        assert len(result) == 2
+        assert result[0]["episode"] in ("01", "1", "?")
+        assert result[1]["season"] in ("02", "2", 0, "0")
+
+    def test_nested_subfolders_are_scanned(self):
+        fm = MagicMock()
+        fm.exists.return_value = True
+
+        def isdir(path):
+            return path.endswith("Season 1")
+
+        def listdir(path):
+            if "Show - 1" in path and "Season" not in path:
+                return ["Season 1"]
+            if path.endswith("Season 1") or path.endswith("Season 1/"):
+                return ["ep.mkv"]
+            return []
+
+        fm.isdir.side_effect = isdir
+        fm.isfile.side_effect = lambda p: p.endswith(".mkv")
+        fm.list.side_effect = listdir
+
+        result = Getters.getEpisodes(self._make_host(fm), "/anime/Show - 1")
+        assert len(result) == 1
+        assert result[0]["path"].endswith("ep.mkv")
+
+
+class TestGetTorrentColor:
+    def test_returns_blue_when_title_matches_existing_torrent(self):
+        host = MagicMock(spec=Getters)
+        host.colors = {"Blue": "#00f", "White": "#fff"}
+        host.fileMarkers = {}
+        torrent = Torrent(hash="a", name="My Show - 01.torrent", trackers=[])
+        host.getTorrents.return_value = [torrent]
+
+        with patch.object(Getters, "getTorrentColor_title_cache", {}, create=True):
+            with patch.object(Getters, "getTorrentColor_pat_cache", {}, create=True):
+                with patch.object(Getters, "getTorrentColor_matchs_cache", {}, create=True):
+                    color = Getters.getTorrentColor(host, "My Show - 01.torrent")
+        assert color == "#00f"
+
+    def test_marker_pattern_applies_color(self):
+        host = MagicMock(spec=Getters)
+        host.colors = {"Red": "#f00", "White": "#fff"}
+        host.fileMarkers = {"Red": [r"^\[Batch\]"]}
+        # Marker checks run in the else-branch while iterating known torrent files.
+        other = Torrent(hash="x", name="Unrelated Show 999.torrent", trackers=[])
+        host.getTorrents.return_value = [other]
+        host.formattedTorrentFiles = (time.time(), {"unrelatedshow999"})
+
+        from shared.config.constants import Constants
+
+        for attr in (
+            "getTorrentColor_title_cache",
+            "getTorrentColor_pat_cache",
+            "getTorrentColor_matchs_cache",
+        ):
+            if hasattr(Constants, attr):
+                delattr(Constants, attr)
+
+        # Force pattern cache rebuild for this host's markers
+        import re
+
+        Constants.getTorrentColor_pat_cache = {  # type: ignore[attr-defined]
+            re.compile(pat, re.I): col
+            for col, pats in host.fileMarkers.items()
+            for pat in pats
+        }
+
+        color = Getters.getTorrentColor(host, "[Batch] Complete Series")
+        assert color == "#f00"
+
+
+class TestGetAnimePicturesCache:
+    def test_empty_ids_returns_empty_dict(self):
+        host = MagicMock(spec=Getters)
+        assert Getters.getAnimePicturesCache(host, []) == {}
+
+
+class TestGetDateTextEdges:
+    def test_upcoming_status_includes_days_left(self):
+        future_ts = int(datetime.now(timezone.utc).timestamp() + 86400 * 10)
+        host = MagicMock(spec=Getters)
+        host.getStatus = Getters.getStatus
+        anime = Anime(
+            {
+                "status": None,
+                "date_from": future_ts,
+                "date_to": None,
+                "episodes": 12,
+            }
+        )
+        result = Getters.getDateText(host, anime)
+        assert len(result) == 1
+        assert "days left" in result[0]
+
+
+class TestSaveTorrentDeprecation:
+    def test_delegates_to_database_manager_when_present(self):
+        host = MagicMock(spec=Getters)
+        dm = MagicMock()
+        host._database_manager = dm
+        torrent = Torrent(hash="abc", name="n", trackers=[])
+
+        with pytest.warns(DeprecationWarning):
+            Getters.saveTorrent(host, 1, torrent, save=True)
+
+        dm.save_torrent.assert_called_once_with(1, torrent)
+        dm._database.save.assert_called_once()

--- a/tests/unit/shared/test_logger_edges.py
+++ b/tests/unit/shared/test_logger_edges.py
@@ -1,0 +1,180 @@
+"""Edge case tests for ``shared.telemetry.logger`` (filesystem + singleton behavior)."""
+
+from __future__ import annotations
+
+import builtins
+import os
+from unittest.mock import patch
+
+import pytest
+
+from shared.telemetry.logger import Logger, log
+
+
+@pytest.fixture(autouse=True)
+def _reset_logger_globals(monkeypatch):
+    """Isolate logger singleton state between tests."""
+    monkeypatch.delenv("ANIMEMANAGER_LOGFILE", raising=False)
+    for attr in ("anime_manager_logger", "anime_manager_log_file"):
+        monkeypatch.delattr(builtins, attr, raising=False)
+    yield
+    monkeypatch.delenv("ANIMEMANAGER_LOGFILE", raising=False)
+    for attr in ("anime_manager_logger", "anime_manager_log_file"):
+        monkeypatch.delattr(builtins, attr, raising=False)
+
+
+def _patch_appdata(tmp_path, monkeypatch):
+    logs = tmp_path / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "shared.telemetry.logger.Constants.getAppdata",
+        staticmethod(lambda: str(tmp_path)),
+    )
+    return logs
+
+
+class TestLoggerInit:
+    def test_reuses_existing_builtin_singleton(self, tmp_path, monkeypatch):
+        _patch_appdata(tmp_path, monkeypatch)
+        existing = Logger(logs="ALL")
+        assert getattr(builtins, "anime_manager_logger") is existing
+
+        second = Logger(logs="NONE")
+        # Early-return path must not register a second global logger.
+        assert getattr(builtins, "anime_manager_logger") is existing
+        assert not hasattr(second, "logFile")
+
+    def test_init_logs_uses_env_logfile(self, tmp_path, monkeypatch):
+        logs = _patch_appdata(tmp_path, monkeypatch)
+        log_path = logs / "log_env.txt"
+        log_path.write_text("seed\n", encoding="utf-8")
+        monkeypatch.setenv("ANIMEMANAGER_LOGFILE", str(log_path))
+
+        logger = Logger(logs="ALL")
+        assert logger.logFile == str(log_path)
+
+    def test_init_logs_reuses_recent_file_in_directory(self, tmp_path, monkeypatch):
+        logs = _patch_appdata(tmp_path, monkeypatch)
+        recent = logs / "log_recent.txt"
+        recent.write_text("x\n", encoding="utf-8")
+
+        logger = Logger(logs="ALL")
+        assert os.path.normpath(logger.logFile) == os.path.normpath(str(recent))
+
+    def test_remote_flag_sets_none_mode(self, tmp_path, monkeypatch):
+        _patch_appdata(tmp_path, monkeypatch)
+
+        class RemoteLogger(Logger):
+            remote = True
+
+        logger = RemoteLogger(logs="ALL")
+        assert logger.log_mode == "NONE"
+
+    def test_custom_logs_list_sets_default_mode(self, tmp_path, monkeypatch):
+        _patch_appdata(tmp_path, monkeypatch)
+        logger = Logger(logs=["CUSTOM"])
+        assert logger.log_mode == "DEFAULT"
+
+
+class TestLoggerLog:
+    def test_writes_categorized_message_to_file(self, tmp_path, monkeypatch, capsys):
+        _patch_appdata(tmp_path, monkeypatch)
+        logger = Logger(logs="ALL")
+        logger.log("NETWORK", "hello", "world")
+
+        content = open(logger.logFile, encoding="utf-8").read()
+        assert "NETWORK" in content
+        assert "hello" in content
+        captured = capsys.readouterr()
+        assert "NETWORK" in captured.out
+
+    def test_none_mode_suppresses_console_but_writes_file(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        _patch_appdata(tmp_path, monkeypatch)
+        logger = Logger(logs="NONE")
+        logger.log("NETWORK", "silent console")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        content = open(logger.logFile, encoding="utf-8").read()
+        assert "silent console" in content
+
+    def test_unknown_category_suppresses_console(self, tmp_path, monkeypatch, capsys):
+        _patch_appdata(tmp_path, monkeypatch)
+        logger = Logger(logs="ALL")
+        logger.log("NOT_A_REAL_CATEGORY", "hidden from console")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        content = open(logger.logFile, encoding="utf-8").read()
+        assert "hidden from console" in content
+
+    def test_plain_message_uses_generic_prefix(self, tmp_path, monkeypatch, capsys):
+        _patch_appdata(tmp_path, monkeypatch)
+        logger = Logger(logs="ALL")
+        logger.log("plain message")
+
+        captured = capsys.readouterr()
+        assert "LOG" in captured.out
+
+    def test_logging_callback_invoked(self, tmp_path, monkeypatch):
+        _patch_appdata(tmp_path, monkeypatch)
+        logger = Logger(logs="ALL")
+        seen = []
+        logger.loggingCb = seen.append
+        logger.log("SETTINGS", "cb test")
+        assert len(seen) == 1
+        assert "SETTINGS" in seen[0]
+
+    def test_log_mode_override_per_call(self, tmp_path, monkeypatch, capsys):
+        _patch_appdata(tmp_path, monkeypatch)
+        logger = Logger(logs="NONE")
+        logger.log("NETWORK", "forced", log_mode="ALL")
+        captured = capsys.readouterr()
+        assert "NETWORK" in captured.out
+
+
+class TestLoggerLogRotation:
+    def test_removes_oldest_logs_when_over_size_limit(self, tmp_path, monkeypatch):
+        import time as time_mod
+
+        logs = _patch_appdata(tmp_path, monkeypatch)
+        stale = time_mod.time() - 120
+        old = logs / "log_old.txt"
+        old.write_bytes(b"x" * 30_000)
+        new = logs / "log_new.txt"
+        new.write_bytes(b"y" * 30_000)
+        os.utime(old, (stale, stale))
+        os.utime(new, (stale, stale))
+
+        logger = Logger(logs="ALL")
+        logger.maxLogsSize = 40_000
+        # Avoid initLogs short-circuit via env/builtins from the constructor.
+        monkeypatch.delenv("ANIMEMANAGER_LOGFILE", raising=False)
+        monkeypatch.delattr(builtins, "anime_manager_log_file", raising=False)
+        logger.initLogs()
+
+        remaining = [f for f in os.listdir(logs) if f.startswith("log_")]
+        total_size = sum(os.path.getsize(logs / f) for f in remaining)
+        assert len(remaining) < 2 or total_size < logger.maxLogsSize
+
+
+class TestModuleLogFunction:
+    def test_log_function_creates_singleton(self, tmp_path, monkeypatch, capsys):
+        _patch_appdata(tmp_path, monkeypatch)
+        assert getattr(builtins, "anime_manager_logger", None) is None
+
+        log("MAIN_STATE", "from helper")
+        assert getattr(builtins, "anime_manager_logger", None) is not None
+
+        captured = capsys.readouterr()
+        assert "MAIN_STATE" in captured.out or "from helper" in captured.out
+
+    def test_log_function_reuses_existing_singleton(self, tmp_path, monkeypatch):
+        _patch_appdata(tmp_path, monkeypatch)
+        first = Logger(logs="ALL")
+        builtins.anime_manager_logger = first
+
+        log("SETTINGS", "again")
+        assert getattr(builtins, "anime_manager_logger") is first

--- a/tests/unit/shared/test_security_edges.py
+++ b/tests/unit/shared/test_security_edges.py
@@ -82,6 +82,17 @@ class TestValidateUrlEdges:
         ok, reason = validate_url("https://")
         assert ok is False
 
+    def test_urlparse_exception_returns_unparseable(self, monkeypatch):
+        import shared.security.utils as sec_utils
+
+        def boom(_url):
+            raise ValueError("forced parse failure")
+
+        monkeypatch.setattr(sec_utils, "urlparse", boom)
+        ok, reason = validate_url("https://example.com")
+        assert ok is False
+        assert reason == "unparseable"
+
     def test_scheme_default_is_https_only(self):
         assert DEFAULT_ALLOWED_SCHEMES == ("https",)
 

--- a/tests/unit/shared/test_telemetry_collector_edges.py
+++ b/tests/unit/shared/test_telemetry_collector_edges.py
@@ -51,6 +51,14 @@ class TestCollectorEdges:
         snap = c.snapshot()
         assert snap["timers"] == {}
 
+    def test_snapshot_skips_timer_buckets_with_no_samples(self):
+        c = TelemetryCollector()
+        with c._lock:
+            # Touching the defaultdict allocates an empty deque with no samples.
+            _ = c._timers["never_recorded"]
+        snap = c.snapshot()
+        assert "never_recorded" not in snap["timers"]
+
     def test_set_gauge_overwrites(self):
         c = TelemetryCollector()
         c.set_gauge("g", 1)

--- a/tests/unit/test_general_edges.py
+++ b/tests/unit/test_general_edges.py
@@ -17,14 +17,27 @@ from shared.utils.general import (
     dict_merge,
     merge_iter,
     new_iter,
+    parse_args,
     peek,
     persist_manager_settings,
+    project_modules,
 )
 
 
 # ---------------------------------------------------------------------------
 # peek
 # ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_filters_kwargs_to_widget_config_keys(self):
+        class _Widget:
+            @staticmethod
+            def config():
+                return {"width": 100, "height": 200}
+
+        out = parse_args(_Widget(), {"width": 10, "unknown": 99})
+        assert out == {"width": 10}
 
 
 class TestPeekEdges:
@@ -119,6 +132,19 @@ class TestTimerEdges:
 # ---------------------------------------------------------------------------
 # persist_manager_settings
 # ---------------------------------------------------------------------------
+
+
+class TestProjectModules:
+    def test_collects_imports_from_python_files(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "mod.py").write_text(
+            "from os import path\nimport json\n",
+            encoding="utf-8",
+        )
+        result = project_modules(str(pkg))
+        assert "os" in result or "json" in result
+        assert any(str(pkg / "mod.py") in loc[0] for loc in result.values())
 
 
 class TestPersistManagerSettingsEdges:

--- a/tests/unit/test_getters.py
+++ b/tests/unit/test_getters.py
@@ -169,6 +169,19 @@ class TestGettersInstanceMethods:
                 assert result == mock_instance
 
     @pytest.mark.timeout(30)
+    def test_getFeatureFlag_reads_bool_and_string_values(self):
+        mock_getters = MagicMock(spec=Getters)
+        mock_getters.settings = {
+            "feature_flags": {
+                "anime_merge_backfill_enabled": "true",
+                "other_flag": 0,
+            }
+        }
+        assert Getters.getFeatureFlag(mock_getters, "anime_merge_backfill_enabled") is True
+        assert Getters.getFeatureFlag(mock_getters, "other_flag") is False
+        assert Getters.getFeatureFlag(mock_getters, "missing", default=True) is True
+
+    @pytest.mark.timeout(30)
     def test_getTorrents_no_id(self):
         """Test getTorrents without id."""
         mock_getters = MagicMock(spec=Getters)
@@ -242,6 +255,41 @@ class TestGettersInstanceMethods:
 
         assert len(result) >= 2
         assert "Since" in result[0]
+
+    @pytest.mark.timeout(30)
+    def test_scan_subdirectory_finds_nested_anime_folder(self):
+        """Series folders nested under animePath (e.g. …/Animes/Title - id) resolve."""
+        mock_self = MagicMock()
+        fm = MagicMock()
+        mock_self.fm = fm
+
+        def norm(p: str) -> str:
+            return str(p).replace("\\", "/")
+
+        existing = {
+            "/root",
+            "/root/Animes",
+            "/root/Animes/Classroom of Elite - 1090",
+        }
+
+        fm.exists.side_effect = lambda p: norm(p) in existing
+
+        fm.isdir.side_effect = lambda p: norm(p) in existing
+
+        def listdir(path: str):
+            p = norm(path)
+            if p == "/root":
+                return ["Animes"]
+            if p == "/root/Animes":
+                return ["Classroom of Elite - 1090"]
+            return []
+
+        fm.list.side_effect = listdir
+
+        result = Getters._scan_subdirectory_for_existing_anime_folder(
+            mock_self, "/root", 1090
+        )
+        assert result == "/root/Animes/Classroom of Elite - 1090"
 
     @pytest.mark.timeout(30)
     def test_getDateText_unknown(self):


### PR DESCRIPTION
## Summary
- Adds `/ui/api/*` JSON routes and SDK/facade methods for the UI cutover.
- Refreshes legacy Jinja/HTMX templates and sets API as the default bootstrap mode.

Stacked on #4.

## Test plan
- [ ] `pytest tests/unit/clients/test_http_ui_api.py tests/unit/clients/test_http_web_cutover.py`
- [ ] `python run.py api` and smoke-test `/ui/api/meta`